### PR TITLE
Allow get_records to return etag.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 6.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Allow to grab the collection ETag. (#80)
 
 
 6.0.0 (2016-06-10)

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -109,7 +109,8 @@ class Client(object):
         }
         return self.endpoints.get(name, **kwargs)
 
-    def _paginated(self, endpoint, records=None, if_none_match=None, **kwargs):
+    def _paginated(self, endpoint, records=None, if_none_match=None,
+                   with_etag=None, **kwargs):
         if records is None:
             records = collections.OrderedDict()
         headers = {}
@@ -128,6 +129,8 @@ class Client(object):
                 next_page = headers['Next-Page']
                 return self._paginated(next_page, records,
                                        if_none_match=if_none_match)
+        if with_etag:
+            return records.values(), headers['ETag']
         return records.values()
 
     def _get_cache_headers(self, safe, data=None, if_match=None):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -537,6 +537,13 @@ class RecordTest(unittest.TestCase):
         records = self.client.get_records()
         assert list(records) == [{'id': 'foo'}, {'id': 'bar'}]
 
+    def test_collection_can_return_collection_etag(self):
+        mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
+                      headers={"ETag": '"123456"'})
+        records, etag = self.client.get_records(with_etag=True)
+        assert list(records) == [{'id': 'foo'}, {'id': 'bar'}]
+        assert etag == '"123456"'
+
     def test_pagination_is_followed(self):
         # Mock the calls to request.
         link = ('http://example.org/buckets/buck/collections/coll/records/'


### PR DESCRIPTION
Add an option to be able to get the collection records ETag.
r? @leplatrem 