### PR TITLE
Add `get_records_timestamp()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This document describes changes between each past release.
 6.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**New features**
+
+- Add a ``get_records_timestamp`` method to get the collection ``ETag``. (#81)
 
 
 6.0.0 (2016-06-10)

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,10 @@ A record is a dict with the "permissions" and "data" keys.
                          collection='todos', bucket='default')
 
     # Retrieve all records.
-    record = client.get_records(collection='todos', bucket='default')
+    records = client.get_records(collection='todos', bucket='default')
+
+    # Retrieve records timestamp.
+    records_timestamp = client.get_records_timestamp(collection='todos', bucket='default')
 
     # Retrieve a specific record and update it.
     record = client.get_record('89881454-e4e9-4ef0-99a9-404d95900352',

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -121,8 +121,9 @@ class Client(object):
             'get', endpoint, headers=headers, params=kwargs)
 
         # Save the current records collection timestamp
-        etag = headers['ETag'].strip('"')
-        self._records_collection_timestamp[endpoint] = etag
+        if 'etag' in map(str.lower, headers.keys()):
+            etag = headers['ETag'].strip('"')
+            self._records_collection_timestamp[endpoint] = etag
 
         if record_resp:
             records_tuples = [(r['id'], r) for r in record_resp['data']]

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -69,6 +69,7 @@ class Client(object):
         self._bucket_name = bucket
         self._collection_name = collection
         self._server_settings = None
+        self._records_collection_timestamp = {}
 
     def clone(self, **kwargs):
         kwargs.setdefault('session', self.session)
@@ -118,6 +119,11 @@ class Client(object):
 
         record_resp, headers = self.session.request(
             'get', endpoint, headers=headers, params=kwargs)
+
+        # Save the current records collection timestamp
+        etag = headers['ETag'].strip('"')
+        self._records_collection_timestamp[endpoint] = etag
+
         if record_resp:
             records_tuples = [(r['id'], r) for r in record_resp['data']]
             records.update(collections.OrderedDict(records_tuples))
@@ -293,6 +299,15 @@ class Client(object):
         return resp['data']
 
     # Records
+
+    def records_collection_timestamp(self, collection=None, bucket=None,
+                                     **kwargs):
+        endpoint = self.get_endpoint('records',
+                                     bucket=bucket,
+                                     collection=collection)
+        if endpoint not in self._records_collection_timestamp:
+            self._paginated(endpoint, **kwargs)
+        return self._records_collection_timestamp[endpoint]
 
     def get_records(self, collection=None, bucket=None, **kwargs):
         """Returns all the records"""

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -306,8 +306,7 @@ class Client(object):
                                      bucket=bucket,
                                      collection=collection)
         if endpoint not in self._records_timestamp:
-            record_resp, headers = self.session.request(
-                'get', endpoint, params=kwargs)
+            record_resp, headers = self.session.request('head', endpoint)
 
             # Save the current records collection timestamp
             etag = headers.get('ETag', '').strip('"')

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -537,6 +537,34 @@ class RecordTest(unittest.TestCase):
         records = self.client.get_records()
         assert list(records) == [{'id': 'foo'}, {'id': 'bar'}]
 
+    def test_collection_can_retrieve_records_collection_timestamp(self):
+        mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
+                      headers={"ETag": '"12345"'})
+        timestamp = self.client.records_collection_timestamp()
+        assert timestamp == '12345'
+
+    def test_records_collection_timestamp_is_cached(self):
+        mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
+                      headers={"ETag": '"12345"'})
+        self.client.get_records()
+        timestamp = self.client.records_collection_timestamp()
+        assert timestamp == '12345'
+        assert self.session.request.call_count == 1
+
+    def test_records_collection_timestamp_is_cached_per_collection(self):
+        mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
+                      headers={"ETag": '"12345"'})
+        self.client.get_records(collection="foo")
+        mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
+                      headers={"ETag": '"67890"'})
+        self.client.get_records(collection="bar")
+
+        timestamp = self.client.records_collection_timestamp("foo")
+        assert timestamp == '12345'
+
+        timestamp = self.client.records_collection_timestamp("bar")
+        assert timestamp == '67890'
+
     def test_pagination_is_followed(self):
         # Mock the calls to request.
         link = ('http://example.org/buckets/buck/collections/coll/records/'

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -537,21 +537,21 @@ class RecordTest(unittest.TestCase):
         records = self.client.get_records()
         assert list(records) == [{'id': 'foo'}, {'id': 'bar'}]
 
-    def test_collection_can_retrieve_records_collection_timestamp(self):
+    def test_collection_can_retrieve_records_timestamp(self):
         mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
                       headers={"ETag": '"12345"'})
-        timestamp = self.client.records_collection_timestamp()
+        timestamp = self.client.get_records_timestamp()
         assert timestamp == '12345'
 
-    def test_records_collection_timestamp_is_cached(self):
+    def test_records_timestamp_is_cached(self):
         mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
                       headers={"ETag": '"12345"'})
         self.client.get_records()
-        timestamp = self.client.records_collection_timestamp()
+        timestamp = self.client.get_records_timestamp()
         assert timestamp == '12345'
         assert self.session.request.call_count == 1
 
-    def test_records_collection_timestamp_is_cached_per_collection(self):
+    def test_records_timestamp_is_cached_per_collection(self):
         mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}],
                       headers={"ETag": '"12345"'})
         self.client.get_records(collection="foo")
@@ -559,10 +559,10 @@ class RecordTest(unittest.TestCase):
                       headers={"ETag": '"67890"'})
         self.client.get_records(collection="bar")
 
-        timestamp = self.client.records_collection_timestamp("foo")
+        timestamp = self.client.get_records_timestamp("foo")
         assert timestamp == '12345'
 
-        timestamp = self.client.records_collection_timestamp("bar")
+        timestamp = self.client.get_records_timestamp("bar")
         assert timestamp == '67890'
 
     def test_pagination_is_followed(self):


### PR DESCRIPTION
As suggested by @leplatrem in #80 let's create another method to get it back.

- [x] Add tests
- [x] Add docs
- [x] Add changelog