### PR TITLE
Fixing clone method to reuse the source session

### DIFF
--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -171,6 +171,14 @@ class Client(object):
             get_method = getattr(self, 'get_%s' % resource)
             return get_method(**get_kwargs)
 
+    def _delete_if_exists(self, resource, **kwargs) :
+        try :
+            delete_method = getattr(self, 'delete_%s' % resource)
+            return delete_method(**kwargs)
+        except KintoException as e:
+            if not hasattr(e, 'response') or e.response.status_code != 404:
+                raise e
+
     # Server Info
 
     def server_info(self):
@@ -290,7 +298,13 @@ class Client(object):
         return resp
 
     def delete_collection(self, collection=None, bucket=None,
-                          safe=True, if_match=None):
+                          safe=True, if_match=None, if_exists=False):
+        if if_exists :
+            return self._delete_if_exists('collection',
+                                          collection=collection,
+                                          bucket=bucket,
+                                          safe=safe,
+                                          if_match=if_match)
         endpoint = self.get_endpoint('collection',
                                      bucket=bucket,
                                      collection=collection)

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -60,21 +60,27 @@ class Client(object):
     def __init__(self, server_url=None, session=None, auth=None,
                  bucket="default", collection=None, retry=0, retry_after=None):
         self.endpoints = Endpoints()
-        self.session_kwargs = dict(server_url=server_url,
-                                   auth=auth,
-                                   session=session,
-                                   retry=retry,
-                                   retry_after=retry_after)
-        self.session = create_session(**self.session_kwargs)
+        session_kwargs = dict(server_url=server_url,
+                              auth=auth,
+                              session=session,
+                              retry=retry,
+                              retry_after=retry_after)
+        self.session = create_session(**session_kwargs)
         self._bucket_name = bucket
         self._collection_name = collection
         self._server_settings = None
         self._records_timestamp = {}
 
     def clone(self, **kwargs):
-        kwargs.setdefault('session', self.session)
+        if 'server_url' in kwargs or 'auth' in kwargs:
+            kwargs.setdefault('server_url', self.session.server_url)
+            kwargs.setdefault('auth', self.session.auth)
+        else:
+            kwargs.setdefault('session', self.session)
         kwargs.setdefault('bucket', self._bucket_name)
         kwargs.setdefault('collection', self._collection_name)
+        kwargs.setdefault('retry', self.session.nb_retry)
+        kwargs.setdefault('retry_after', self.session.retry_after)
         return Client(**kwargs)
 
     @contextmanager

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -128,6 +128,12 @@ class FunctionalTest(unittest2.TestCase):
         self.client.delete_collection('payments', bucket='mozilla')
         assert len(self.client.get_collections(bucket='mozilla')) == 0
 
+    def test_collection_deletion_if_exists(self):
+        self.client.create_bucket('mozilla')
+        self.client.create_collection('payments', bucket='mozilla')
+        self.client.delete_collection('payments', bucket='mozilla')
+        self.client.delete_collection('payments', bucket='mozilla', if_exists=True)
+
     def test_collections_deletion(self):
         self.client.create_bucket('mozilla')
         self.client.create_collection('amo', bucket='mozilla')

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -116,6 +116,13 @@ class ClientTest(unittest.TestCase):
     def test_client_clone_with_new_session(self) :
         client_clone = self.client.clone(session="")
 
+    def test_client_clone_with_new_bucket_and_collection(self) :
+        client_clone = self.client.clone(bucket="blah", collection="blah")
+
+    def test_client_clone_with_auth_and_server_url_bucket_and_collection(self) :
+        client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1", bucket="blah", collection="blah")
+
+
 class BucketTest(unittest.TestCase):
 
     def setUp(self):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 from six import text_type
 from .support import unittest, mock_response, build_response, get_http_error
 
@@ -102,25 +103,32 @@ class ClientTest(unittest.TestCase):
         assert client._bucket_name == "buck"
 
     def test_client_clone_with_auth(self) :
-        client_clone = self.client.clone(auth=("reviewer", ""))
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(auth=("reviewer", ""))
 
     def test_client_clone_with_server_url(self) :
-        client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
 
     def test_client_clone_with_existing_session(self) :
-        client_clone = self.client.clone(session=self.client.session)
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(session=self.client.session)
 
     def test_client_clone_with_auth_and_server_url(self) :
-        client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1")
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1")
 
     def test_client_clone_with_new_session(self) :
-        client_clone = self.client.clone(session="")
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(session="")
 
     def test_client_clone_with_new_bucket_and_collection(self) :
-        client_clone = self.client.clone(bucket="blah", collection="blah")
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(bucket="blah", collection="blah")
 
     def test_client_clone_with_auth_and_server_url_bucket_and_collection(self) :
-        client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1", bucket="blah", collection="blah")
+        with pytest.raises(AttributeError):
+            client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1", bucket="blah", collection="blah")
 
 
 class BucketTest(unittest.TestCase):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -111,7 +111,7 @@ class ClientTest(unittest.TestCase):
 
     def test_client_clone_with_session(self) :
         with self.assertRaises(KintoException) :
-            client_clone = self.client.clone(self.session)
+            client_clone = self.client.clone(self.client.session)
 
 
 class BucketTest(unittest.TestCase):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -103,15 +103,15 @@ class ClientTest(unittest.TestCase):
 
     def test_client_clone_with_auth(self) :
         with self.assertRaises(KintoException) :
-            client = self.clone(auth=("reviewer", ""))
+            client_clone = self.client.clone(auth=("reviewer", ""))
 
     def test_client_clone_with_server_url(self) :
         with self.assertRaises(KintoException) :
-            client = self.clone(server_url="https://kinto.notmyidea.org/v1")
+            client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
 
     def test_client_clone_with_session(self) :
         with self.assertRaises(KintoException) :
-            client = self.clone(self.session)
+            client_clone = self.client.clone(self.session)
 
 
 class BucketTest(unittest.TestCase):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -101,6 +101,18 @@ class ClientTest(unittest.TestCase):
             bucket="buck")
         assert client._bucket_name == "buck"
 
+    def test_client_clone_with_auth(self) :
+        with self.assertRaises(KintoException) :
+            client = self.clone(auth=("reviewer", ""))
+
+    def test_client_clone_with_server_url(self) :
+        with self.assertRaises(KintoException) :
+            client = self.clone(server_url="https://kinto.notmyidea.org/v1")
+
+    def test_client_clone_with_session(self) :
+        with self.assertRaises(KintoException) :
+            client = self.clone(self.session)
+
 
 class BucketTest(unittest.TestCase):
 

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -111,7 +111,7 @@ class ClientTest(unittest.TestCase):
 
     def test_client_clone_with_session(self) :
         with self.assertRaises(KintoException) :
-            client_clone = self.client.clone(self.client.session)
+            client_clone = self.client.clone(session=self.client.session)
 
 
 class BucketTest(unittest.TestCase):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -5,6 +5,7 @@ from .support import unittest, mock_response, build_response, get_http_error
 
 from kinto_http import (KintoException, BucketNotFound, Client,
                         DO_NOT_OVERWRITE)
+from kinto_http.session import create_session
 
 
 class ClientTest(unittest.TestCase):
@@ -102,33 +103,86 @@ class ClientTest(unittest.TestCase):
             bucket="buck")
         assert client._bucket_name == "buck"
 
-    def test_client_clone_with_auth(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(auth=("reviewer", ""))
+    def test_client_clone_with_auth(self):
+        client_clone = self.client.clone(auth=("reviewer", ""))
+        assert client_clone.session.auth == ("reviewer", "")
+        assert self.client.session != client_clone.session
+        assert self.client.session.server_url == client_clone.session.server_url
+        assert self.client.session.auth != client_clone.session.auth
+        assert self.client.session.nb_retry == client_clone.session.nb_retry
+        assert self.client.session.retry_after == client_clone.session.retry_after
+        assert self.client._bucket_name == client_clone._bucket_name
+        assert self.client._collection_name == client_clone._collection_name
 
-    def test_client_clone_with_server_url(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
+    def test_client_clone_with_server_url(self):
+        client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
+        assert client_clone.session.server_url == "https://kinto.notmyidea.org/v1"
+        assert self.client.session != client_clone.session
+        assert self.client.session.server_url != client_clone.session.server_url
+        assert self.client.session.auth == client_clone.session.auth
+        assert self.client.session.nb_retry == client_clone.session.nb_retry
+        assert self.client.session.retry_after == client_clone.session.retry_after
+        assert self.client._bucket_name == client_clone._bucket_name
+        assert self.client._collection_name == client_clone._collection_name
 
-    def test_client_clone_with_existing_session(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(session=self.client.session)
+    def test_client_clone_with_new_session(self):
+        session = create_session(auth=("reviewer", ""),
+                                 server_url="https://kinto.notmyidea.org/v1")
+        client_clone = self.client.clone(session=session)
+        assert client_clone.session == session
+        assert self.client.session != client_clone.session
+        assert self.client.session.server_url != client_clone.session.server_url
+        assert self.client.session.auth != client_clone.session.auth
+        assert self.client._bucket_name == client_clone._bucket_name
+        assert self.client._collection_name == client_clone._collection_name
 
-    def test_client_clone_with_auth_and_server_url(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1")
+    def test_client_clone_with_auth_and_server_url(self):
+        client_clone = self.client.clone(auth=("reviewer", ""),
+                                         server_url="https://kinto.notmyidea.org/v1")
+        assert client_clone.session.auth == ("reviewer", "")
+        assert client_clone.session.server_url == "https://kinto.notmyidea.org/v1"
+        assert self.client.session != client_clone.session
+        assert self.client.session.server_url != client_clone.session.server_url
+        assert self.client.session.auth != client_clone.session.auth
+        assert self.client.session.nb_retry == client_clone.session.nb_retry
+        assert self.client.session.retry_after == client_clone.session.retry_after
+        assert self.client._bucket_name == client_clone._bucket_name
+        assert self.client._collection_name == client_clone._collection_name
 
-    def test_client_clone_with_new_session(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(session="")
+    def test_client_clone_with_existing_session(self):
+        client_clone = self.client.clone(session=self.client.session)
+        assert self.client.session == client_clone.session
+        assert self.client.session.server_url == client_clone.session.server_url
+        assert self.client.session.auth == client_clone.session.auth
+        assert self.client._bucket_name == client_clone._bucket_name
+        assert self.client._collection_name == client_clone._collection_name
 
-    def test_client_clone_with_new_bucket_and_collection(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(bucket="blah", collection="blah")
+    def test_client_clone_with_new_bucket_and_collection(self):
+        client_clone = self.client.clone(bucket="bucket_blah", collection="coll_blah")
+        assert self.client.session == client_clone.session
+        assert self.client.session.server_url == client_clone.session.server_url
+        assert self.client.session.auth == client_clone.session.auth
+        assert self.client.session.nb_retry == client_clone.session.nb_retry
+        assert self.client.session.retry_after == client_clone.session.retry_after
+        assert self.client._bucket_name != client_clone._bucket_name
+        assert self.client._collection_name != client_clone._collection_name
+        assert client_clone._bucket_name == "bucket_blah"
+        assert client_clone._collection_name == "coll_blah"
 
-    def test_client_clone_with_auth_and_server_url_bucket_and_collection(self) :
-        with pytest.raises(AttributeError):
-            client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1", bucket="blah", collection="blah")
+    def test_client_clone_with_auth_and_server_url_bucket_and_collection(self):
+        client_clone = self.client.clone(auth=("reviewer", ""),
+                                         server_url="https://kinto.notmyidea.org/v1",
+                                         bucket="bucket_blah",
+                                         collection="coll_blah")
+        assert self.client.session != client_clone.session
+        assert self.client.session.server_url != client_clone.session.server_url
+        assert self.client.session.auth != client_clone.session.auth
+        assert self.client._bucket_name != client_clone._bucket_name
+        assert self.client._collection_name != client_clone._collection_name
+        assert client_clone.session.auth == ("reviewer", "")
+        assert client_clone.session.server_url == "https://kinto.notmyidea.org/v1"
+        assert client_clone._bucket_name == "bucket_blah"
+        assert client_clone._collection_name == "coll_blah"
 
 
 class BucketTest(unittest.TestCase):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -1,10 +1,8 @@
 import mock
-import pytest
 from six import text_type
 from .support import unittest, mock_response, build_response, get_http_error
 
-from kinto_http import (KintoException, BucketNotFound, Client,
-                        DO_NOT_OVERWRITE)
+from kinto_http import KintoException, BucketNotFound, Client, DO_NOT_OVERWRITE
 from kinto_http.session import create_session
 
 

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -102,17 +102,19 @@ class ClientTest(unittest.TestCase):
         assert client._bucket_name == "buck"
 
     def test_client_clone_with_auth(self) :
-        with self.assertRaises(KintoException) :
-            client_clone = self.client.clone(auth=("reviewer", ""))
+        client_clone = self.client.clone(auth=("reviewer", ""))
 
     def test_client_clone_with_server_url(self) :
-        with self.assertRaises(KintoException) :
-            client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
+        client_clone = self.client.clone(server_url="https://kinto.notmyidea.org/v1")
 
-    def test_client_clone_with_session(self) :
-        with self.assertRaises(KintoException) :
-            client_clone = self.client.clone(session=self.client.session)
+    def test_client_clone_with_existing_session(self) :
+        client_clone = self.client.clone(session=self.client.session)
 
+    def test_client_clone_with_auth_and_server_url(self) :
+        client_clone = self.client.clone(auth=("reviewer", ""), server_url="https://kinto.notmyidea.org/v1")
+
+    def test_client_clone_with_new_session(self) :
+        client_clone = self.client.clone(session="")
 
 class BucketTest(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,6 @@ install_command = pip install --pre {opts} {packages}
 commands = flake8 kinto_http
 deps =
     flake8
+
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
Tests for #88 
@Natim I got the following errors when using the clone method : 
- when changing only server_url
- when changing only auth
- when specifying a session 

**Errors**
kinto_http/tests/test_client.py::ClientTest::test_client_clone_with_auth
kinto_http/tests/test_client.py::ClientTest::test_client_clone_with_server_url
kinto_http/tests/test_client.py::ClientTest::test_client_clone_with_session