### PR TITLE
Prevent odict_values error on Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: python
+sudo: true
 python: 2.7
+addons:
+  apt:
+    sources:
+      - deadsnakes # source required so it finds the package definition below
+    packages:
+      - python3.5
+      - python3.5-dev
 env:
     - TOX_ENV=py27
     - TOX_ENV=py34
+    - TOX_ENV=py35
+    - TOX_ENV=py35 SERVER=development
     - TOX_ENV=flake8
 before_install:
-    - if [[ $SERVER != development ]]; then pip install kinto; fi
-    - if [[ $SERVER == development ]]; then pip install https://github.com/Kinto/kinto/tarball/master; fi
-    - make install-dev
-    - make runkinto &
+    - VIRTUAL_ENV=.venv make VIRTUALENV="virtualenv --python python3.5" install-dev
+    - VIRTUAL_ENV=.venv make VIRTUALENV="virtualenv --python python3.5" runkinto &
+    - if [[ $SERVER == development ]]; then .venv/bin/pip install https://github.com/Kinto/kinto/tarball/master; fi
 install:
     - pip install tox
 script:
@@ -17,8 +26,3 @@ after_success:
     # Report coverage results to coveralls.io
     - pip install coveralls
     - coveralls
-matrix:
-  include:
-    - python: 3.5
-      env:
-        - TOX_ENV=py35 SERVER=development

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: true
 python: 2.7
 addons:
   apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This document describes changes between each past release.
 7.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Method for plural endpoints now return list of objects instead of ``odict_values``.
 
 
 7.0.0 (2016-09-30)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIRTUALENV = virtualenv
+VIRTUALENV = virtualenv --python python3
 VENV := $(shell echo $${VIRTUAL_ENV-.venv})
 PYTHON = $(VENV)/bin/python
 DEV_STAMP = $(VENV)/.dev_env_installed.stamp
@@ -30,6 +30,7 @@ need-kinto-running:
 	@curl http://localhost:8888/v0/ 2>/dev/null 1>&2 || (echo "Run 'make runkinto' before starting tests." && exit 1)
 
 runkinto: install-dev
+	$(VENV)/bin/python --version
 	$(VENV)/bin/kinto --ini kinto_http/tests/config/kinto.ini migrate
 	$(VENV)/bin/kinto --ini kinto_http/tests/config/kinto.ini start
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIRTUALENV = virtualenv --python python3
+VIRTUALENV = virtualenv
 VENV := $(shell echo $${VIRTUAL_ENV-.venv})
 PYTHON = $(VENV)/bin/python
 DEV_STAMP = $(VENV)/.dev_env_installed.stamp
@@ -24,15 +24,15 @@ $(DEV_STAMP): $(PYTHON) dev-requirements.txt
 
 virtualenv: $(PYTHON)
 $(PYTHON):
-	virtualenv $(VENV)
+	$(VIRTUALENV) $(VENV)
 
 need-kinto-running:
 	@curl http://localhost:8888/v0/ 2>/dev/null 1>&2 || (echo "Run 'make runkinto' before starting tests." && exit 1)
 
 runkinto: install-dev
 	$(VENV)/bin/python --version
-	$(VENV)/bin/kinto --ini kinto_http/tests/config/kinto.ini migrate
-	$(VENV)/bin/kinto --ini kinto_http/tests/config/kinto.ini start
+	$(VENV)/bin/kinto migrate --ini kinto_http/tests/config/kinto.ini
+	$(VENV)/bin/kinto start --ini kinto_http/tests/config/kinto.ini
 
 tests-once: install-dev
 	$(VENV)/bin/py.test --cov-report term-missing --cov-fail-under 100 --cov kinto_http

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ need-kinto-running:
 	@curl http://localhost:8888/v0/ 2>/dev/null 1>&2 || (echo "Run 'make runkinto' before starting tests." && exit 1)
 
 runkinto: install-dev
-	$(VENV)/bin/python --version
 	$(VENV)/bin/kinto migrate --ini kinto_http/tests/config/kinto.ini
 	$(VENV)/bin/kinto start --ini kinto_http/tests/config/kinto.ini
 

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -145,7 +145,7 @@ class Client(object):
                 next_page = headers['Next-Page']
                 return self._paginated(next_page, records,
                                        if_none_match=if_none_match)
-        return records.values()
+        return list(records.values())
 
     def _get_cache_headers(self, safe, data=None, if_match=None):
         has_data = data is not None and data.get('last_modified')

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -1,13 +1,12 @@
-import os.path
-from six.moves.urllib.parse import urljoin
-
+import hashlib
+import hmac
 import mock
+import os.path
 import pytest
-import unittest2
 import requests
+import unittest2
 from six.moves import configparser
-
-from kinto.core import utils as kinto_core_utils
+from six.moves.urllib.parse import urljoin
 
 from kinto_http import Client, BucketNotFound, KintoException
 from kinto_http import replication
@@ -16,6 +15,16 @@ __HERE__ = os.path.abspath(os.path.dirname(__file__))
 
 SERVER_URL = "http://localhost:8888/v1"
 DEFAULT_AUTH = ('user', 'p4ssw0rd')
+
+
+# Backported from kinto.core.utils
+def hmac_digest(secret, message, encoding='utf-8'):
+    """Return hex digest of a message HMAC using secret"""
+    if isinstance(secret, str):
+        secret = secret.encode(encoding)
+    return hmac.new(secret,
+                    message.encode(encoding),
+                    hashlib.sha256).hexdigest()
 
 
 class FunctionalTest(unittest2.TestCase):
@@ -40,7 +49,7 @@ class FunctionalTest(unittest2.TestCase):
     def get_user_id(self, credentials):
         hmac_secret = self.config.get('app:main', 'kinto.userid_hmac_secret')
         credentials = '%s:%s' % credentials
-        digest = kinto_core_utils.hmac_digest(hmac_secret, credentials)
+        digest = hmac_digest(hmac_secret, credentials)
         return 'basicauth:%s' % digest
 
     def test_bucket_creation(self):


### PR DESCRIPTION
* `TypeError: can't pickle odict_values objects`
* `TypeError: 'odict_values' object does not support indexing`