### PR TITLE
Support parsing batch results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 8.1.0 (unreleased)
 ==================
 
-- Allow reading from batch contexts using the ``parse_results`` method. (#146)
+- Allow reading responses from batch requests with the ``results()`` method. (#146)
 
 
 8.0.1 (2017-05-16)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 8.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Allow reading from batch contexts using the ``parse_results`` method. (#146)
 
 
 8.0.1 (2017-05-16)

--- a/README.rst
+++ b/README.rst
@@ -325,18 +325,28 @@ Batching operations
 Rather than issuing a request for each and every operation, it is possible to
 batch the requests. The client will then issue as little requests as possible.
 
-Currently, batching operations only supports write operations, so it is not
-possible to do the retrieval of information inside a batch.
-
 It is possible to do batch requests using a Python context manager (``with``):
 
 .. code-block:: python
 
   with client.batch() as batch:
-      for idx in range(0,100):
+      for idx in range(0, 100):
           batch.update_record(data={'id': idx})
 
-A batch object shares the same methods as another client.
+Reading data from batch operations is achived by using the ``parse_results`` method
+available ater a batch context is closed.
+
+.. code-block:: python
+
+  with client.batch() as batch:
+      batch.get_record('r1')
+      batch.get_record('r2')
+      batch.get_record('r3')
+
+  r1, r2, r3 = batch.parse_results()
+
+Besides the ``parse_results`` method, a batch object shares all the same methods as
+another client.
 
 Retry on error
 --------------

--- a/README.rst
+++ b/README.rst
@@ -333,7 +333,7 @@ It is possible to do batch requests using a Python context manager (``with``):
       for idx in range(0, 100):
           batch.update_record(data={'id': idx})
 
-Reading data from batch operations is achived by using the ``parse_results`` method
+Reading data from batch operations is achived by using the ``results()`` method
 available ater a batch context is closed.
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -333,8 +333,8 @@ It is possible to do batch requests using a Python context manager (``with``):
       for idx in range(0, 100):
           batch.update_record(data={'id': idx})
 
-Reading data from batch operations is achived by using the ``results()`` method
-available ater a batch context is closed.
+Reading data from batch operations is achieved by using the ``results()`` method
+available after a batch context is closed.
 
 .. code-block:: python
 
@@ -343,9 +343,9 @@ available ater a batch context is closed.
       batch.get_record('r2')
       batch.get_record('r3')
 
-  r1, r2, r3 = batch.parse_results()
+  r1, r2, r3 = batch.results()
 
-Besides the ``parse_results`` method, a batch object shares all the same methods as
+Besides the ``results()`` method, a batch object shares all the same methods as
 another client.
 
 Retry on error

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -97,6 +97,11 @@ class Client(object):
         batch_session = BatchSession(self,
                                      batch_max_requests=batch_max_requests)
         batch_client = self.clone(session=batch_session, **kwargs)
+
+        # set a reference for parsing results from the context
+        batch_client.results = batch_session.results
+        batch_client.parse_results = batch_session.parse_results
+
         yield batch_client
         batch_session.send()
         batch_session.reset()

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -98,7 +98,7 @@ class Client(object):
                                      batch_max_requests=batch_max_requests)
         batch_client = self.clone(session=batch_session, **kwargs)
 
-        # set a reference for reading results from the context
+        # Set a reference for reading results from the context.
         batch_client.results = batch_session.results
 
         yield batch_client

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -98,9 +98,8 @@ class Client(object):
                                      batch_max_requests=batch_max_requests)
         batch_client = self.clone(session=batch_session, **kwargs)
 
-        # set a reference for parsing results from the context
+        # set a reference for reading results from the context
         batch_client.results = batch_session.results
-        batch_client.parse_results = batch_session.parse_results
 
         yield batch_client
         batch_session.send()

--- a/kinto_http/batch.py
+++ b/kinto_http/batch.py
@@ -11,7 +11,7 @@ class BatchSession(object):
         self.endpoints = client.endpoints
         self.batch_max_requests = batch_max_requests
         self.requests = []
-        self.results = []
+        self._results = []
 
     def request(self, method, endpoint, data=None, permissions=None,
                 headers=None):
@@ -58,15 +58,15 @@ class BatchSession(object):
                     exception.request = chunk[i]
                     exception.response = response
                     raise exception
-            self.results.append((resp, headers))
-        return self.results
+            self._results.append((resp, headers))
+        return self._results
 
-    def parse_results(self):
+    def results(self):
         # Get each batch block response
-        block_responses = [resp for resp, _ in self.results]
+        chunks = [resp for resp, _ in self._results]
 
         responses = []
-        for block in block_responses:
-            responses += block['responses']
+        for chunk in chunks:
+            responses += chunk['responses']
 
         return [resp['body'] for resp in responses]

--- a/kinto_http/batch.py
+++ b/kinto_http/batch.py
@@ -44,6 +44,7 @@ class BatchSession(object):
         return requests
 
     def send(self):
+        self._results = []
         requests = self._build_requests()
         for chunk in utils.chunks(requests, self.batch_max_requests):
             kwargs = dict(method='POST',

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -462,7 +462,7 @@ class FunctionalTest(unittest2.TestCase):
             batch.create_record(data={'bar': 'baz'},
                                 permissions={'read': ['alexis']})
 
-        _, _, r1, r2 = batch.parse_results()
+        _, _, r1, r2 = batch.results()
         records = self.client.get_records(bucket='mozilla', collection='fonts')
 
         assert len(records) == 2

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -462,8 +462,12 @@ class FunctionalTest(unittest2.TestCase):
             batch.create_record(data={'bar': 'baz'},
                                 permissions={'read': ['alexis']})
 
+        _, _, r1, r2 = batch.parse_results()
         records = self.client.get_records(bucket='mozilla', collection='fonts')
+
         assert len(records) == 2
+        assert records[0] == r2['data']
+        assert records[1] == r1['data']
 
     def test_replication(self):
         # First, create a few records on the first kinto collection.

--- a/kinto_http/tests/test_batch.py
+++ b/kinto_http/tests/test_batch.py
@@ -113,12 +113,6 @@ class BatchRequestsTest(unittest.TestCase):
             batch.send()
         assert self.client.session.request.call_count == 1
 
-    def test_results_attribute_is_available(self):
-        batch = BatchSession(self.client)
-        batch.request('GET', '/v1/foobar')
-        batch.send()
-        assert len(batch.results) == 1
-
     def test_parse_results_retrieves_response_data(self):
         batch_response = {
             "body": {"data": {"id": "hey"}},
@@ -131,6 +125,6 @@ class BatchRequestsTest(unittest.TestCase):
         batch.request('GET', '/v1/foobar')
         batch.send()
 
-        results = batch.parse_results()
+        results = batch.results()
         assert len(results) == 1
         assert results[0] == batch_response["body"]

--- a/kinto_http/tests/test_batch.py
+++ b/kinto_http/tests/test_batch.py
@@ -112,3 +112,25 @@ class BatchRequestsTest(unittest.TestCase):
         with self.assertRaises(KintoException):
             batch.send()
         assert self.client.session.request.call_count == 1
+
+    def test_results_attribute_is_available(self):
+        batch = BatchSession(self.client)
+        batch.request('GET', '/v1/foobar')
+        batch.send()
+        assert len(batch.results) == 1
+
+    def test_parse_results_retrieves_response_data(self):
+        batch_response = {
+            "body": {"data": {"id": "hey"}},
+            "status": 200,
+        }
+        mock.sentinel.resp = {"responses": [batch_response]}
+        self.client.session.request.return_value = (mock.sentinel.resp,
+                                                    mock.sentinel.headers)
+        batch = BatchSession(self.client)
+        batch.request('GET', '/v1/foobar')
+        batch.send()
+
+        results = batch.parse_results()
+        assert len(results) == 1
+        assert results[0] == batch_response["body"]


### PR DESCRIPTION
Fixes/Updates #145 

This may not be the best API for this feature, but it does support the use case for dumping records on kinto-wizard (https://github.com/Kinto/kinto-wizard/issues/16).

A small example:

```python
from kinto_http import Client

client = Client('http://localhost:8888/v1',
                auth=('gabi', 'ilovecats'),
                collection='status')

with client.batch() as batch:
    batch.update_record(id='r1', data={'busy': True})
    batch.get_record('r1')

set_r1, get_r1 = batch.results()
assert set_r1 == get_r1
```

Todos:
- [x] Add unit tests
- [x] Update CHANGELOG and README

Opinions?