### PR TITLE
Add strict option to raise on 4XX errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ CHANGELOG
 This document describes changes between each past release.
 
 
-9.2.0 (unreleased)
-==================
+10.0.0 (unreleased)
+===================
 
 **Breaking changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ This document describes changes between each past release.
 9.2.0 (unreleased)
 ==================
 
+**Breaking changes**
+
+By default, the client now raises an exception when a 4XX error occurs in a batch request (#154)
+
+In order to ignore those errors as before, instantiate the client with ``ignore_batch_4xx=True``.
+
 **New feature**
 
 - Raise a specific `CollectionNotFound` exception rather than a generic `KintoException`.

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -8,13 +8,15 @@ import logging
 from kinto_http import utils
 from kinto_http.session import create_session, Session
 from kinto_http.batch import BatchSession
-from kinto_http.exceptions import BucketNotFound, CollectionNotFound, KintoException
+from kinto_http.exceptions import (
+    BucketNotFound, CollectionNotFound, KintoException, KintoBatchException
+)
 from kinto_http.patch_type import PatchType, BasicPatch
 
 logger = logging.getLogger('kinto_http')
 
 __all__ = ('Endpoints', 'Session', 'Client', 'create_session',
-           'BucketNotFound', 'CollectionNotFound', 'KintoException')
+           'BucketNotFound', 'CollectionNotFound', 'KintoException', 'KintoBatchException')
 
 
 OBJECTS_PERMISSIONS = {

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -62,7 +62,8 @@ class Endpoints(object):
 class Client(object):
 
     def __init__(self, *, server_url=None, session=None, auth=None,
-                 bucket="default", collection=None, retry=0, retry_after=None):
+                 bucket="default", collection=None, retry=0, retry_after=None,
+                 strict=False):
         self.endpoints = Endpoints()
         session_kwargs = dict(server_url=server_url,
                               auth=auth,
@@ -74,6 +75,7 @@ class Client(object):
         self._collection_name = collection
         self._server_settings = None
         self._records_timestamp = {}
+        self._strict = strict
 
     def clone(self, **kwargs):
         if 'server_url' in kwargs or 'auth' in kwargs:
@@ -95,7 +97,8 @@ class Client(object):
 
         batch_max_requests = self._server_settings['batch_max_requests']
         batch_session = BatchSession(self,
-                                     batch_max_requests=batch_max_requests)
+                                     batch_max_requests=batch_max_requests,
+                                     strict=self._strict)
         batch_client = self.clone(session=batch_session, **kwargs)
 
         # Set a reference for reading results from the context.

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -63,7 +63,7 @@ class Client(object):
 
     def __init__(self, *, server_url=None, session=None, auth=None,
                  bucket="default", collection=None, retry=0, retry_after=None,
-                 strict=False):
+                 ignore_4xx_errors=False):
         self.endpoints = Endpoints()
         session_kwargs = dict(server_url=server_url,
                               auth=auth,
@@ -75,7 +75,7 @@ class Client(object):
         self._collection_name = collection
         self._server_settings = None
         self._records_timestamp = {}
-        self._strict = strict
+        self._ignore_4xx_errors = ignore_4xx_errors
 
     def clone(self, **kwargs):
         if 'server_url' in kwargs or 'auth' in kwargs:
@@ -98,7 +98,7 @@ class Client(object):
         batch_max_requests = self._server_settings['batch_max_requests']
         batch_session = BatchSession(self,
                                      batch_max_requests=batch_max_requests,
-                                     strict=self._strict)
+                                     ignore_4xx_errors=self._ignore_4xx_errors)
         batch_client = self.clone(session=batch_session, **kwargs)
 
         # Set a reference for reading results from the context.

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -63,7 +63,7 @@ class Client(object):
 
     def __init__(self, *, server_url=None, session=None, auth=None,
                  bucket="default", collection=None, retry=0, retry_after=None,
-                 ignore_4xx_errors=False):
+                 ignore_batch_4xx=False):
         self.endpoints = Endpoints()
         session_kwargs = dict(server_url=server_url,
                               auth=auth,
@@ -75,7 +75,7 @@ class Client(object):
         self._collection_name = collection
         self._server_settings = None
         self._records_timestamp = {}
-        self._ignore_4xx_errors = ignore_4xx_errors
+        self._ignore_batch_4xx = ignore_batch_4xx
 
     def clone(self, **kwargs):
         if 'server_url' in kwargs or 'auth' in kwargs:
@@ -98,7 +98,7 @@ class Client(object):
         batch_max_requests = self._server_settings['batch_max_requests']
         batch_session = BatchSession(self,
                                      batch_max_requests=batch_max_requests,
-                                     ignore_4xx_errors=self._ignore_4xx_errors)
+                                     ignore_4xx_errors=self._ignore_batch_4xx)
         batch_client = self.clone(session=batch_session, **kwargs)
 
         # Set a reference for reading results from the context.

--- a/kinto_http/batch.py
+++ b/kinto_http/batch.py
@@ -11,11 +11,11 @@ logger = logging.getLogger(__name__)
 
 class BatchSession(object):
 
-    def __init__(self, client, batch_max_requests=0, strict=False):
+    def __init__(self, client, batch_max_requests=0, ignore_4xx_errors=False):
         self.session = client.session
         self.endpoints = client.endpoints
         self.batch_max_requests = batch_max_requests
-        self._strict = strict
+        self._ignore_4xx_errors = ignore_4xx_errors
         self.requests = []
         self._results = []
 
@@ -78,8 +78,8 @@ class BatchSession(object):
                     exception = KintoException(message)
                     exception.request = chunk[i]
                     exception.response = response
-                    # Raise in case of a 500
-                    if status_code >= 500 or self._strict:
+                    raise_on_4xx = status_code >= 400 and not self._ignore_4xx_errors
+                    if status_code >= 500 or raise_on_4xx:
                         raise exception
 
                 id_request += 1

--- a/kinto_http/batch.py
+++ b/kinto_http/batch.py
@@ -113,7 +113,7 @@ class BatchSession(object):
             self._results.append((resp, headers))
 
         if _exceptions:
-            raise KintoBatchException(_exceptions)
+            raise KintoBatchException(_exceptions, self._results)
 
         return self._results
 

--- a/kinto_http/cli_utils.py
+++ b/kinto_http/cli_utils.py
@@ -25,7 +25,7 @@ def create_client_from_args(args):
                   collection=getattr(args, 'collection', None),
                   retry=args.retry,
                   retry_after=args.retry_after,
-                  ignore_4xx_errors=args.ignore_4xx_errors)
+                  ignore_batch_4xx=args.ignore_batch_4xx)
 
 
 class AuthAction(argparse.Action):
@@ -40,7 +40,7 @@ def add_parser_options(parser=None,
                        default_auth=None,
                        default_retry=0,
                        default_retry_after=None,
-                       default_ignore_4xx=False,
+                       default_ignore_batch_4xx=False,
                        default_bucket=None,
                        default_collection=None,
                        include_bucket=True,
@@ -77,10 +77,10 @@ def add_parser_options(parser=None,
                         '(default: provided by server)',
                         type=int, default=default_retry_after)
 
-    parser.add_argument('--ignore-4XX-errors',
-                        help='Do not fail on 4XX errors in batch requests.',
-                        default=default_ignore_4xx, action='store_true',
-                        dest='ignore_4xx_errors')
+    parser.add_argument('--ignore-batch-4xx',
+                        help='Do not fail on 4xx errors in batch requests.',
+                        default=default_ignore_batch_4xx, action='store_true',
+                        dest='ignore_batch_4xx')
 
     # Defaults
     parser.add_argument('-v', '--verbose', action='store_const',

--- a/kinto_http/cli_utils.py
+++ b/kinto_http/cli_utils.py
@@ -24,7 +24,8 @@ def create_client_from_args(args):
                   bucket=getattr(args, 'bucket', None),
                   collection=getattr(args, 'collection', None),
                   retry=args.retry,
-                  retry_after=args.retry_after)
+                  retry_after=args.retry_after,
+                  strict=args.strict)
 
 
 class AuthAction(argparse.Action):
@@ -39,6 +40,7 @@ def add_parser_options(parser=None,
                        default_auth=None,
                        default_retry=0,
                        default_retry_after=None,
+                       default_strict=False,
                        default_bucket=None,
                        default_collection=None,
                        include_bucket=True,
@@ -74,6 +76,10 @@ def add_parser_options(parser=None,
                         help='Delay in seconds between retries when requests fail. '
                         '(default: provided by server)',
                         type=int, default=default_retry_after)
+
+    parser.add_argument('--strict',
+                        help='Fail on 4XX errors.',
+                        default=default_strict, action='store_true')
 
     # Defaults
     parser.add_argument('-v', '--verbose', action='store_const',

--- a/kinto_http/cli_utils.py
+++ b/kinto_http/cli_utils.py
@@ -25,7 +25,7 @@ def create_client_from_args(args):
                   collection=getattr(args, 'collection', None),
                   retry=args.retry,
                   retry_after=args.retry_after,
-                  strict=args.strict)
+                  ignore_4xx_errors=args.ignore_4xx_errors)
 
 
 class AuthAction(argparse.Action):
@@ -40,7 +40,7 @@ def add_parser_options(parser=None,
                        default_auth=None,
                        default_retry=0,
                        default_retry_after=None,
-                       default_strict=False,
+                       default_ignore_4xx=False,
                        default_bucket=None,
                        default_collection=None,
                        include_bucket=True,
@@ -77,9 +77,10 @@ def add_parser_options(parser=None,
                         '(default: provided by server)',
                         type=int, default=default_retry_after)
 
-    parser.add_argument('--strict',
-                        help='Fail on 4XX errors.',
-                        default=default_strict, action='store_true')
+    parser.add_argument('--ignore-4XX-errors',
+                        help='Do not fail on 4XX errors in batch requests.',
+                        default=default_ignore_4xx, action='store_true',
+                        dest='ignore_4xx_errors')
 
     # Defaults
     parser.add_argument('-v', '--verbose', action='store_const',

--- a/kinto_http/exceptions.py
+++ b/kinto_http/exceptions.py
@@ -32,3 +32,9 @@ class BackoffException(KintoException):
     def __init__(self, message, backoff, exception=None):
         self.backoff = backoff
         super().__init__(message, exception)
+
+
+class KintoBatchException(KintoException):
+    def __init__(self, exceptions):
+        self.message = "\n".join([str(e) for e in exceptions])
+        self.exceptions = exceptions

--- a/kinto_http/exceptions.py
+++ b/kinto_http/exceptions.py
@@ -35,6 +35,7 @@ class BackoffException(KintoException):
 
 
 class KintoBatchException(KintoException):
-    def __init__(self, exceptions):
+    def __init__(self, exceptions, results):
         self.message = "\n".join([str(e) for e in exceptions])
         self.exceptions = exceptions
+        self.results = results

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -17,8 +17,7 @@ USER_AGENT = 'kinto_http/{} requests/{} python/{}'.format(kinto_http_version,
                                                           requests_version, python_version)
 
 
-def create_session(server_url=None, auth=None, session=None, retry=0, retry_after=None):
-
+def create_session(server_url=None, auth=None, session=None, **kwargs):
     """Returns a session from the passed arguments.
 
     :param server_url:
@@ -39,8 +38,7 @@ def create_session(server_url=None, auth=None, session=None, retry=0, retry_afte
         msg = ("You need to either set session or auth + server_url")
         raise AttributeError(msg)
     if session is None:
-        session = Session(server_url=server_url, auth=auth, retry=retry,
-                          retry_after=retry_after)
+        session = Session(server_url=server_url, auth=auth, **kwargs)
     return session
 
 

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -141,11 +141,7 @@ class FunctionalTest(unittest.TestCase):
         with pytest.raises(KintoException) as e:
             self.client.create_group(
                 id='payments', bucket='mozilla',
-                data={'members': ['blah', ]})
-            self.client.create_group(
-                id='payments', bucket='mozilla',
-                data={'members': ['blah', ]},
-                if_not_exists=True)
+                data={'members': ['blah']})
         assert str(e).endswith('PUT /v1/buckets/mozilla/groups/payments - '
                                '403 Unauthorized. Please check that the '
                                'bucket exists and that you have the permission '

--- a/kinto_http/tests/test_cli_utils.py
+++ b/kinto_http/tests/test_cli_utils.py
@@ -12,7 +12,7 @@ ALL_PARAMETERS = [
     ['-c', '--collection'],
     ['--retry'],
     ['--retry-after'],
-    ['--ignore-4xx-errors'],
+    ['--ignore-batch-4xx'],
     ['-v', '--verbose'],
     ['-q', '--quiet'],
     ['-D', '--debug'],
@@ -29,7 +29,7 @@ class ParserServerOptionsTest(unittest.TestCase):
     def test_add_parser_options_create_a_parser_if_needed(self):
         parser = cli_utils.add_parser_options()
         self.assert_option_strings(parser, *ALL_PARAMETERS)
-        assert len(parser._actions) == 10
+        assert len(parser._actions) == len(ALL_PARAMETERS)
 
     def test_add_parser_options_adds_arguments_on_existing_parser(self):
         parser = argparse.ArgumentParser(prog="importer")
@@ -39,7 +39,7 @@ class ParserServerOptionsTest(unittest.TestCase):
         parser = cli_utils.add_parser_options(parser)
         self.assert_option_strings(parser, ['-t', '--type'],
                                    *ALL_PARAMETERS)
-        assert len(parser._actions) == 11
+        assert len(parser._actions) == len(ALL_PARAMETERS) + 1
 
     def test_add_parser_options_can_ignore_bucket_and_collection(self):
         parser = cli_utils.add_parser_options(
@@ -50,12 +50,13 @@ class ParserServerOptionsTest(unittest.TestCase):
             ['-a', '--auth'],
             ['--retry'],
             ['--retry-after'],
+            ['--ignore-batch-4xx'],
             ['-v', '--verbose'],
             ['-q', '--quiet'],
             ['-D', '--debug'],
         ]
         self.assert_option_strings(parser, *parameters)
-        assert len(parser._actions) == 8
+        assert len(parser._actions) == len(parameters)
 
     def test_can_change_default_values(self):
         parser = cli_utils.add_parser_options(
@@ -74,7 +75,8 @@ class ParserServerOptionsTest(unittest.TestCase):
             'collection': 'certificates',
             'retry': 0,
             'retry_after': None,
-            'verbosity': None
+            'verbosity': None,
+            'ignore_batch_4xx': False,
         }
 
 
@@ -119,7 +121,7 @@ class ClientFromArgsTest(unittest.TestCase):
             auth=('user', 'password'),
             bucket='blocklists',
             collection='certificates',
-            ignore_4xx_errors=False,
+            ignore_batch_4xx=False,
             retry=0,
             retry_after=None)
 
@@ -140,7 +142,7 @@ class ClientFromArgsTest(unittest.TestCase):
             auth=('user', 'password'),
             bucket='blocklists',
             collection='certificates',
-            ignore_4xx_errors=False,
+            ignore_batch_4xx=False,
             retry=3,
             retry_after=None)
 
@@ -161,6 +163,6 @@ class ClientFromArgsTest(unittest.TestCase):
             auth=('user', 'password'),
             bucket=None,
             collection=None,
-            ignore_4xx_errors=False,
+            ignore_batch_4xx=False,
             retry=0,
             retry_after=None)

--- a/kinto_http/tests/test_cli_utils.py
+++ b/kinto_http/tests/test_cli_utils.py
@@ -12,6 +12,7 @@ ALL_PARAMETERS = [
     ['-c', '--collection'],
     ['--retry'],
     ['--retry-after'],
+    ['--ignore-4xx-errors'],
     ['-v', '--verbose'],
     ['-q', '--quiet'],
     ['-D', '--debug'],
@@ -118,6 +119,7 @@ class ClientFromArgsTest(unittest.TestCase):
             auth=('user', 'password'),
             bucket='blocklists',
             collection='certificates',
+            ignore_4xx_errors=False,
             retry=0,
             retry_after=None)
 
@@ -138,6 +140,7 @@ class ClientFromArgsTest(unittest.TestCase):
             auth=('user', 'password'),
             bucket='blocklists',
             collection='certificates',
+            ignore_4xx_errors=False,
             retry=3,
             retry_after=None)
 
@@ -158,5 +161,6 @@ class ClientFromArgsTest(unittest.TestCase):
             auth=('user', 'password'),
             bucket=None,
             collection=None,
+            ignore_4xx_errors=False,
             retry=0,
             retry_after=None)

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from kinto_http import (KintoException, KintoBatchException, BucketNotFound,
-    Client, DO_NOT_OVERWRITE)
+                        Client, DO_NOT_OVERWRITE)
 from kinto_http.session import create_session
 from kinto_http.patch_type import MergePatch, JSONPatch
 

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -119,6 +119,9 @@ class ClientTest(unittest.TestCase):
         assert isinstance(raised.exceptions[0], KintoException)
         assert raised.exceptions[0].response.status_code == 403
         assert raised.exceptions[1].response.status_code == 400
+        resp, headers = raised.results[0]
+        assert len(resp["responses"]) == 4
+        assert resp["responses"][0]["status"] == 200
 
     def test_batch_does_not_raise_exception_if_batch_4xx_errors_are_ignored(self):
         error = {

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -148,9 +148,7 @@ class SessionTest(unittest.TestCase):
                        auth=mock.sentinel.auth)
         session_mock.assert_called_with(
             server_url=mock.sentinel.server_url,
-            auth=mock.sentinel.auth,
-            retry=0,
-            retry_after=None)
+            auth=mock.sentinel.auth)
 
     def test_use_given_session_if_provided(self):
         session = create_session(session=mock.sentinel.session)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ test_requirements = [
 ]
 
 setup(name='kinto-http',
-      version='9.2.0.dev0',
+      version='10.0.0.dev0',
       description='Kinto client',
       long_description=README,
       license='Apache License (2.0)',


### PR DESCRIPTION
In #148 a breaking change was introduced to avoid raising on 4XX responses in a batch.

This is a proposition to restore the old behaviour with a flag.

What do you think?