### PR TITLE
Don't mutate caller

### DIFF
--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -80,7 +80,7 @@ class Session(object):
             kwargs.setdefault(payload_kwarg, payload)
 
         # Set the default User-Agent if not already defined.
-        if 'headers' not in kwargs or kwargs['headers'] == None:
+        if 'headers' not in kwargs or kwargs['headers'] is None:
             kwargs['headers'] = {}
         if not isinstance(kwargs['headers'], dict):
             raise TypeError("headers must be a dict (got {})".format(kwargs['headers']))

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -80,9 +80,12 @@ class Session(object):
             kwargs.setdefault(payload_kwarg, payload)
 
         # Set the default User-Agent if not already defined.
-        if not isinstance(kwargs.get('headers'), dict):
+        if 'headers' not in kwargs or kwargs['headers'] == None:
             kwargs['headers'] = {}
-        kwargs['headers'].setdefault('User-Agent', USER_AGENT)
+        if not isinstance(kwargs['headers'], dict):
+            raise TypeError("headers must be a dict (got {})".format(kwargs['headers']))
+
+        kwargs['headers'] = {"User-Agent": USER_AGENT, **kwargs['headers']}
 
         retry = self.nb_retry
         while retry >= 0:

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -33,11 +33,11 @@ class ClientTest(unittest.TestCase):
                 {'body': {'data': {'foo': 'bar'}},
                  'path': '/buckets/mozilla/collections/test/records/1234',
                  'method': 'PUT',
-                 'headers': {'If-None-Match': '*', 'User-Agent': USER_AGENT}},
+                 'headers': {'If-None-Match': '*'}},
                 {'body': {'data': {'bar': 'baz'}},
                  'path': '/buckets/mozilla/collections/test/records/5678',
                  'method': 'PUT',
-                 'headers': {'If-None-Match': '*', 'User-Agent': USER_AGENT}}]})
+                 'headers': {'If-None-Match': '*'}}]})
 
     def test_batch_raises_exception(self):
         # Make the next call to sess.request raise a 403.

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -2,7 +2,6 @@ import mock
 import pytest
 from six import text_type
 from .support import unittest, mock_response, build_response, get_http_error
-from kinto_http.session import USER_AGENT
 from kinto_http import KintoException, BucketNotFound, Client, DO_NOT_OVERWRITE
 from kinto_http.session import create_session
 

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -76,6 +76,12 @@ class SessionTest(unittest.TestCase):
             'get', 'https://example.org/test',
             foo=mock.sentinel.bar, headers=self.requests_mock.request.return_value.headers)
 
+    def test_raises_exception_if_headers_not_dict(self):
+        session = Session('https://example.org')
+
+        with pytest.raises(TypeError) as e:
+            session.request('get', '/test', headers=4)
+
     def test_passed_data_is_encoded_to_json(self):
         response = fake_response(200)
         self.requests_mock.request.return_value = response


### PR DESCRIPTION
While working on #158, I noticed that running `py.test kinto_http/tests` caused a test failure, but `py.test kinto_http/tests/functional.py kinto_http/tests` caused the tests to pass. That indicated that some state was being modified somewhere, which isn't good. It turned out that this call to `setdefault` was modifying a headers dictionary that came from a global argument. Fix that.