### PR TITLE
Fix README about patch changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,10 +150,10 @@ If no specific bucket name is provided, the "default" bucket is used.
 
     # Or modify some fields in an existing bucket.
     # The Kinto server supports different types of patches, which can be used from kinto_http.patch_type.
-    client.patch_bucket(id='payments', data=BasicPatch({'status': 'updated'}))
+    client.patch_bucket(id='payments', changes=BasicPatch({'status': 'updated'}))
 
     # It is also possible to manipulate bucket permissions (see later)
-    client.patch_bucket(id='payments', data=BasicPatch(permissions={}))
+    client.patch_bucket(id='payments', changes=BasicPatch(permissions={}))
 
     # Or delete a bucket and everything under.
     client.delete_bucket(id='payment')
@@ -184,7 +184,7 @@ A group associates a name to a list of principals. It is useful in order to hand
     # Or modify some fields in an existing group.
     # This uses the server's support for JSON patch, but any patch_type is accepted.
     client.patch_group(id='receipts', bucket='payments',
-        data=JSONPatch([{'op': 'add', 'location': 'description', 'value': 'my group'}]))
+        changes=JSONPatch([{'op': 'add', 'path': '/data/members/0', 'value': 'ldap:user@corp.com'}]))
 
     # To delete an existing group.
     client.delete_group(id='receipts', bucket='payments')
@@ -213,7 +213,7 @@ A collection is where records are stored.
     client.update_collection(id='receipts', bucket='payments', data={'description':'bleeh'})
 
     # Or modify some fields of an existing collection.
-    client.patch_collection(id='receipts', bucket='payments', data=MergePatch({'status':'updated'}))
+    client.patch_collection(id='receipts', bucket='payments', changes=MergePatch({'status':'updated'}))
 
     # To delete an existing collection.
     client.delete_collection(id='receipts', bucket='payments')
@@ -255,7 +255,7 @@ A record is a dict with the "permissions" and "data" keys.
     client.update_record(data={'status': 'unknown'}, id='todo2', collection='todos', bucket='default')
 
     # Or modify some fields in an existing record.
-    client.patch_record(data=MergePatch({'assignee': 'bob'}), id='todo2', collection='todos', bucket='default')
+    client.patch_record(changes=MergePatch({'assignee': 'bob'}), id='todo2', collection='todos', bucket='default')
 
     # To delete an existing record.
     client.delete_record(id='89881454-e4e9-4ef0-99a9-404d95900352',


### PR DESCRIPTION
When using a `JSONPatch` in ` data`, we have the following error `AttributeError: 'JSONPatch' object has no attribute 'get'`

It works when using it in `changes=`...