### PR TITLE
Remove deprecated test functions

### DIFF
--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -171,7 +171,7 @@ class FunctionalTest(unittest.TestCase):
         groups = self.client.get_groups(bucket='mozilla')
         self.assertEqual(2, len(groups))
         self.assertEqual(set([coll['id'] for coll in groups]),
-                          set(['receipts', 'assets']))
+                         set(['receipts', 'assets']))
 
     def test_group_deletion(self):
         self.client.create_bucket(id='mozilla')
@@ -240,7 +240,7 @@ class FunctionalTest(unittest.TestCase):
         self.assertEqual(len(collections), 2)
 
         self.assertEqual(set([coll['id'] for coll in collections]),
-                          set(['receipts', 'assets']))
+                         set(['receipts', 'assets']))
 
     def test_collection_deletion(self):
         self.client.create_bucket(id='mozilla')

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -161,7 +161,7 @@ class FunctionalTest(unittest.TestCase):
         group = self.client.update_group(
                     data={'members': ['blah', 'foo']},
                     id='payments', bucket='mozilla')
-        self.assertEquals(group['data']['members'][1], 'foo')
+        self.assertEqual(group['data']['members'][1], 'foo')
 
     def test_group_list(self):
         self.client.create_bucket(id='mozilla')
@@ -169,8 +169,8 @@ class FunctionalTest(unittest.TestCase):
         self.client.create_group(id='assets', bucket='mozilla', data={'members': ['blah', ]})
         # The returned groups should be strings.
         groups = self.client.get_groups(bucket='mozilla')
-        self.assertEquals(2, len(groups))
-        self.assertEquals(set([coll['id'] for coll in groups]),
+        self.assertEqual(2, len(groups))
+        self.assertEqual(set([coll['id'] for coll in groups]),
                           set(['receipts', 'assets']))
 
     def test_group_deletion(self):
@@ -237,9 +237,9 @@ class FunctionalTest(unittest.TestCase):
 
         # The returned collections should be strings.
         collections = self.client.get_collections(bucket='mozilla')
-        self.assertEquals(2, len(collections))
+        self.assertEqual(len(collections), 2)
 
-        self.assertEquals(set([coll['id'] for coll in collections]),
+        self.assertEqual(set([coll['id'] for coll in collections]),
                           set(['receipts', 'assets']))
 
     def test_collection_deletion(self):

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -313,9 +313,9 @@ class BucketTest(unittest.TestCase):
         with self.assertRaises(BucketNotFound) as cm:
             self.client.get_bucket(id='test')
         e = cm.exception
-        self.assertEquals(e.response, exception.response)
-        self.assertEquals(e.request, mock.sentinel.request)
-        self.assertEquals(e.message, 'test')
+        self.assertEqual(e.response, exception.response)
+        self.assertEqual(e.request, mock.sentinel.request)
+        self.assertEqual(e.message, 'test')
 
     def test_unauthorized_raises_a_kinto_exception(self):
         # Make the next call to sess.request raise a 401.
@@ -328,9 +328,9 @@ class BucketTest(unittest.TestCase):
         with self.assertRaises(KintoException) as cm:
             self.client.get_bucket(id='test')
         e = cm.exception
-        self.assertEquals(e.response, exception.response)
-        self.assertEquals(e.request, mock.sentinel.request)
-        self.assertEquals(e.message,
+        self.assertEqual(e.response, exception.response)
+        self.assertEqual(e.request, mock.sentinel.request)
+        self.assertEqual(e.message,
                           "Unauthorized. Please authenticate or make sure the bucket "
                           "can be read anonymously.")
 
@@ -345,8 +345,8 @@ class BucketTest(unittest.TestCase):
         try:
             self.client.get_bucket(id='test')
         except KintoException as e:
-            self.assertEquals(e.response, exception.response)
-            self.assertEquals(e.request, mock.sentinel.request)
+            self.assertEqual(e.response, exception.response)
+            self.assertEqual(e.request, mock.sentinel.request)
         else:
             self.fail("Exception not raised")
 
@@ -640,7 +640,7 @@ class RecordTest(unittest.TestCase):
         id = self.session.request.mock_calls[0][1][1].split('/')[-1]
 
         uuid_regexp = r'[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}'
-        self.assertRegexpMatches(id, uuid_regexp)
+        self.assertRegex(id, uuid_regexp)
 
     def test_records_handles_permissions(self):
         mock_response(self.session)
@@ -724,7 +724,7 @@ class RecordTest(unittest.TestCase):
         mock_response(self.session, data={'foo': 'bar'})
         record = self.client.get_record(id='1234')
 
-        self.assertEquals(record['data'], {'foo': 'bar'})
+        self.assertEqual(record['data'], {'foo': 'bar'})
         url = '/buckets/mybucket/collections/mycollection/records/1234'
         self.session.request.assert_called_with('get', url)
 

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -331,8 +331,8 @@ class BucketTest(unittest.TestCase):
         self.assertEqual(e.response, exception.response)
         self.assertEqual(e.request, mock.sentinel.request)
         self.assertEqual(e.message,
-                          "Unauthorized. Please authenticate or make sure the bucket "
-                          "can be read anonymously.")
+                         "Unauthorized. Please authenticate or make sure the bucket "
+                         "can be read anonymously.")
 
     def test_http_500_raises_an_error(self):
         exception = KintoException()

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -26,13 +26,13 @@ class SessionTest(unittest.TestCase):
 
     def test_uses_specified_server_url(self):
         session = Session(mock.sentinel.server_url)
-        self.assertEquals(session.server_url, mock.sentinel.server_url)
+        self.assertEqual(session.server_url, mock.sentinel.server_url)
 
     def test_no_auth_is_used_by_default(self):
         response = fake_response(200)
         self.requests_mock.request.return_value = response
         session = Session('https://example.org')
-        self.assertEquals(session.auth, None)
+        self.assertEqual(session.auth, None)
         session.request('get', '/test')
         self.requests_mock.request.assert_called_with(
             'get', 'https://example.org/test',
@@ -154,7 +154,7 @@ class SessionTest(unittest.TestCase):
 
     def test_use_given_session_if_provided(self):
         session = create_session(session=mock.sentinel.session)
-        self.assertEquals(session, mock.sentinel.session)
+        self.assertEqual(session, mock.sentinel.session)
 
     def test_body_is_none_on_304(self):
         response = fake_response(304)

--- a/kinto_http/tests/test_utils.py
+++ b/kinto_http/tests/test_utils.py
@@ -23,23 +23,23 @@ class UtilsTest(TestCase):
 
     def test_urljoin_can_join_with_trailing_slash(self):
         url = utils.urljoin("http://localhost/", "v1")
-        self.assertEquals(url, "http://localhost/v1")
+        self.assertEqual(url, "http://localhost/v1")
 
     def test_urljoin_can_join_with_prepend_slash(self):
         url = utils.urljoin("http://localhost", "/v1")
-        self.assertEquals(url, "http://localhost/v1")
+        self.assertEqual(url, "http://localhost/v1")
 
     def test_urljoin_can_join_with_both_trailing_and_prepend_slash(self):
         url = utils.urljoin("http://localhost/", "/v1")
-        self.assertEquals(url, "http://localhost/v1")
+        self.assertEqual(url, "http://localhost/v1")
 
     def test_urljoin_can_join_prefixed_server_url(self):
         url = utils.urljoin("http://localhost/v1/", "/tests")
-        self.assertEquals(url, "http://localhost/v1/tests")
+        self.assertEqual(url, "http://localhost/v1/tests")
 
     def test_urljoin_can_join_without_trailing_nor_prepend_slash(self):
         url = utils.urljoin("http://localhost", "v1")
-        self.assertEquals(url, "http://localhost/v1")
+        self.assertEqual(url, "http://localhost/v1")
 
     def test_quote_strips_extra_quotes(self):
         assert utils.quote('"1234"') == '"1234"'


### PR DESCRIPTION
After spending some time looking at kinto I ran into this project and noticed it could probably use some love as well.

So here is a start removing deprecated asserts