### PR TITLE
kinto-http.py should take care of params JSON encoding.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ This document describes changes between each past release.
 10.1.0 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Convert params values as JSON values before passing them to requests. (#185)
 
 
 10.0.0 (2018-10-15)

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -1,3 +1,4 @@
+import json
 import pkg_resources
 import sys
 import time
@@ -70,6 +71,9 @@ class Session(object):
 
         if kwargs.get('headers') is None:
             kwargs['headers'] = dict()
+
+        if kwargs.get('params') is not None:
+            kwargs['params'] = {k: json.dumps(v).strip('"') for k, v in kwargs["params"].items()}
 
         if not isinstance(kwargs['headers'], dict):
             raise TypeError("headers must be a dict (got {})".format(kwargs['headers']))

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -243,12 +243,12 @@ class SessionJSONTest(unittest.TestCase):
                                  price=12,
                                  contains_id=["toto", "tata"]))
         self.requests_mock.request.assert_called_with(
-            'get', '/buckets/buck/collections/coll/records', params={
+            'get', 'https://example.org/v1/buckets/buck/collections/coll/records', params={
                 "_sort": "-published_date",
                 "is_published": "true",
                 "price": "12",
-                "contains_id": '["toto","tata"]'
-            })
+                "contains_id": '["toto", "tata"]'
+            }, headers=self.requests_mock.request.headers)
 
 
 class RetryRequestTest(unittest.TestCase):

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -231,6 +231,25 @@ class SessionJSONTest(unittest.TestCase):
             data='{"data": {"foo": "2018-06-22"}}',
             headers=self.requests_mock.request.post_json_headers)
 
+    def test_request_converts_params(self):
+        response = mock.MagicMock()
+        response.headers = {}
+        response.status_code = 200
+        self.requests_mock.request.return_value = response
+        self.session.request('get', '/v1/buckets/buck/collections/coll/records',
+                             params=dict(
+                                 _sort="-published_date",
+                                 is_published=True,
+                                 price=12,
+                                 contains_id=["toto", "tata"]))
+        self.requests_mock.request.assert_called_with(
+            'get', '/buckets/buck/collections/coll/records', params={
+                "_sort": "-published_date",
+                "is_published": "true",
+                "price": "12",
+                "contains_id": '["toto","tata"]'
+            })
+
 
 class RetryRequestTest(unittest.TestCase):
 


### PR DESCRIPTION
Using `is_published=True` as a params doesn't work, probably because requests turn it into a `is_published=True` rather than a `is_published=true`