### PR TITLE
Expose methods for paginated lists (fixes #175)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This document describes changes between each past release.
 10.2.0 (unreleased)
 ===================
 
-- Nothing changed yet.
+**New feature**
+
+- Created new method on client to get paginated records``get_paginated_records``. (#175)
 
 
 10.1.1 (2018-11-13)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ This document describes changes between each past release.
 
 **New feature**
 
-- Created new method on client to get paginated records``get_paginated_records``. (#175)
+- Created new method on client to get paginated records ``get_paginated_records``. (#175)
 
 
 10.1.1 (2018-11-13)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIRTUALENV = virtualenv --python=python3.6
+VIRTUALENV = virtualenv --python=python3
 VENV := $(shell echo $${VIRTUAL_ENV-.venv})
 PYTHON = $(VENV)/bin/python
 DEV_STAMP = $(VENV)/.dev_env_installed.stamp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIRTUALENV = virtualenv --python=python3
+VIRTUALENV = virtualenv --python=python3.6
 VENV := $(shell echo $${VIRTUAL_ENV-.venv})
 PYTHON = $(VENV)/bin/python
 DEV_STAMP = $(VENV)/.dev_env_installed.stamp

--- a/README.rst
+++ b/README.rst
@@ -265,8 +265,8 @@ A record is a dict with the "permissions" and "data" keys.
     # Or retrieve all records.
     records = client.get_records(collection='todos', bucket='default')
 
-   # Or retrive records page by page.
-   for page in client.get_paginated_records(collection='todos', bucket='dafult'):
+   # Or retrieve records page by page.
+   for page in client.get_paginated_records(collection='todos', bucket='default'):
       # Do something with each page
       print(page)
 

--- a/README.rst
+++ b/README.rst
@@ -265,6 +265,11 @@ A record is a dict with the "permissions" and "data" keys.
     # Or retrieve all records.
     records = client.get_records(collection='todos', bucket='default')
 
+   # Or retrive records page by page.
+   for page in client.get_paginated_records(collection='todos', bucket='dafult'):
+      # Do something with each page
+      print(page)
+
     # Or retrieve records timestamp.
     records_timestamp = client.get_records_timestamp(collection='todos', bucket='default')
 

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -664,6 +664,8 @@ class Client(object):
 
     def _paginated_generator(self, endpoint, *, if_none_match=None, **kwargs):
         headers = {}
+        if if_none_match is not None:
+            headers['If-None-Match'] = utils.quote(if_none_match)
 
         record_resp, headers = self.session.request(
             'get', endpoint, headers=headers, params=kwargs)

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -660,9 +660,9 @@ class Client(object):
                                      bucket=bucket,
                                      collection=collection)
 
-        yield from self._paginated_gen(endpoint, **kwargs)
+        return self._paginated_generator(endpoint, **kwargs)
 
-    def _paginated_gen(self, endpoint, records=None, *, if_none_match=None, **kwargs):
+    def _paginated_generator(self, endpoint, *, if_none_match=None, **kwargs):
         headers = {}
 
         record_resp, headers = self.session.request(
@@ -673,8 +673,8 @@ class Client(object):
 
         if 'next-page' in map(str.lower, headers.keys()):
             next_page = headers['Next-Page']
-            yield from self._paginated_gen(next_page,
-                                           if_none_match=if_none_match)
+            yield from self._paginated_generator(next_page,
+                                                 if_none_match=if_none_match)
 
     def get_record(self, *, id, collection=None, bucket=None):
         endpoint = self.get_endpoint('record', id=id,

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -664,8 +664,8 @@ class Client(object):
 
     def _paginated_gen(self, endpoint, records=None, *, if_none_match=None, **kwargs):
         headers = {}
-        if if_none_match is not None:
-            headers['If-None-Match'] = utils.quote(if_none_match)
+        #if if_none_match is not None:
+        #    headers['If-None-Match'] = utils.quote(if_none_match)
 
         record_resp, headers = self.session.request(
             'get', endpoint, headers=headers, params=kwargs)

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -664,8 +664,6 @@ class Client(object):
 
     def _paginated_gen(self, endpoint, records=None, *, if_none_match=None, **kwargs):
         headers = {}
-        #if if_none_match is not None:
-        #    headers['If-None-Match'] = utils.quote(if_none_match)
 
         record_resp, headers = self.session.request(
             'get', endpoint, headers=headers, params=kwargs)

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -311,6 +311,20 @@ class FunctionalTest(unittest.TestCase):
         records = client.get_records()
         assert len(records) == 10
 
+
+    def test_records_generator_retrieval(self):
+        client = Client(server_url=self.server_url, auth=self.auth,
+                        bucket='mozilla', collection='payments')
+        client.create_bucket()
+        client.create_collection()
+        for i in range(10):
+            client.create_record(data={'foo': 'bar'},
+                                 permissions={'read': ['account:alexis']})
+
+        pages = sum(1 for i in client.get_paginated_records())
+
+        assert(pages == 2)
+
     def test_single_record_save(self):
         client = Client(server_url=self.server_url, auth=self.auth,
                         bucket='mozilla', collection='payments')

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -320,9 +320,9 @@ class FunctionalTest(unittest.TestCase):
             client.create_record(data={'foo': 'bar'},
                                  permissions={'read': ['account:alexis']})
 
-        pages = sum(1 for i in client.get_paginated_records())
+        pages = list(client.get_paginated_records())
 
-        assert(pages == 2)
+        assert len(pages) == 2
 
     def test_single_record_save(self):
         client = Client(server_url=self.server_url, auth=self.auth,

--- a/kinto_http/tests/functional.py
+++ b/kinto_http/tests/functional.py
@@ -311,7 +311,6 @@ class FunctionalTest(unittest.TestCase):
         records = client.get_records()
         assert len(records) == 10
 
-
     def test_records_generator_retrieval(self):
         client = Client(server_url=self.server_url, auth=self.auth,
                         bucket='mozilla', collection='payments')

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -833,6 +833,48 @@ class RecordTest(unittest.TestCase):
             {'id': '6', 'value': 'item6'},
         ]
 
+    def test_pagination_is_followed_generator(self):
+        # Mock the calls to request.
+        link = ('http://example.org/buckets/buck/collections/coll/records/'
+                '?token=1234')
+
+        self.session.request.side_effect = [
+            # First one returns a list of items with a pagination token.
+            build_response(
+                [{'id': '1', 'value': 'item1'},
+                 {'id': '2', 'value': 'item2'}, ],
+                 {'Next-Page': link}),
+            build_response(
+                [{'id': '3', 'value': 'item3'},
+                 {'id': '4', 'value': 'item4'}, ],
+                 {'Next-Page': link}),
+            # Second one returns a list of items without a pagination token.
+            build_response(
+                [{'id': '5', 'value': 'item5'},
+                 {'id': '6', 'value': 'item6'}, ],
+            ),
+        ]
+
+        response = [
+            # First one returns a list of items with a pagination token.
+            build_response(
+                [{'id': '1', 'value': 'item1'},
+                 {'id': '2', 'value': 'item2'}, ],
+            )[0],
+            build_response(
+                [{'id': '3', 'value': 'item3'},
+                 {'id': '4', 'value': 'item4'}, ]
+            )[0],
+            # Second one returns a list of items without a pagination token.
+            build_response(
+                [{'id': '5', 'value': 'item5'},
+                 {'id': '6', 'value': 'item6'}, ],
+            )[0],
+        ]
+
+        for index, page_records in enumerate(self.client.get_paginated_records()):
+            assert response[index] == page_records
+
     def test_pagination_is_followed_for_number_of_pages(self):
         # Mock the calls to request.
         link = ('http://example.org/buckets/buck/collections/coll/records/'

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -843,11 +843,11 @@ class RecordTest(unittest.TestCase):
             build_response(
                 [{'id': '1', 'value': 'item1'},
                  {'id': '2', 'value': 'item2'}, ],
-            ),
+                {'Next-Page': link}),
             build_response(
                 [{'id': '3', 'value': 'item3'},
-                 {'id': '4', 'value': 'item4'}, ]
-            ),
+                 {'id': '4', 'value': 'item4'}, ],
+                {'Next-Page': link}),
             # Second one returns a list of items without a pagination token.
             build_response(
                 [{'id': '5', 'value': 'item5'},

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -941,7 +941,6 @@ class RecordTest(unittest.TestCase):
         self.session.request.assert_any_call(
             'get', link, headers={'If-None-Match': '"1234"'}, params={})
 
-
     def test_pagination_generator_if_none_match(self):
         link = ('http://example.org/buckets/buck/collections/coll/records/'
                 '?token=1234')
@@ -968,7 +967,8 @@ class RecordTest(unittest.TestCase):
         # Build repsonses for assertion without next page
         response = [record[0] for record in response]
 
-        for index, page_records in enumerate(self.client.get_paginated_records(if_none_match="1234")):
+        for index, page_records in enumerate(self.client.get_paginated_records(
+                                             if_none_match="1234")):
             # Check that the If-None-Match header is present in the requests.
             assert response[index] == page_records
 

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -941,6 +941,41 @@ class RecordTest(unittest.TestCase):
         self.session.request.assert_any_call(
             'get', link, headers={'If-None-Match': '"1234"'}, params={})
 
+
+    def test_pagination_generator_if_none_match(self):
+        link = ('http://example.org/buckets/buck/collections/coll/records/'
+                '?token=1234')
+
+        response = [
+            # First one returns a list of items with a pagination token.
+            build_response(
+                [{'id': '1', 'value': 'item1'},
+                 {'id': '2', 'value': 'item2'}, ],
+                {'Next-Page': link}),
+            build_response(
+                [{'id': '3', 'value': 'item3'},
+                 {'id': '4', 'value': 'item4'}, ],
+                {'Next-Page': link}),
+            # Second one returns a list of items without a pagination token.
+            build_response(
+                [{'id': '5', 'value': 'item5'},
+                 {'id': '6', 'value': 'item6'}, ],
+            ),
+        ]
+
+        self.session.request.side_effect = response
+
+        # Build repsonses for assertion without next page
+        response = [record[0] for record in response]
+
+        for index, page_records in enumerate(self.client.get_paginated_records(if_none_match="1234")):
+            # Check that the If-None-Match header is present in the requests.
+            assert response[index] == page_records
+
+        # Check that the If-None-Match header is present in the requests.
+        self.session.request.assert_any_call(
+            'get', link, headers={'If-None-Match': '"1234"'}, params={})
+
     def test_collection_can_delete_a_record(self):
         mock_response(self.session, data={'id': 1234})
         resp = self.client.delete_record(id=1234)

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -838,16 +838,16 @@ class RecordTest(unittest.TestCase):
         link = ('http://example.org/buckets/buck/collections/coll/records/'
                 '?token=1234')
 
-        self.session.request.side_effect = [
+        response = [
             # First one returns a list of items with a pagination token.
             build_response(
                 [{'id': '1', 'value': 'item1'},
                  {'id': '2', 'value': 'item2'}, ],
-                 {'Next-Page': link}),
+            ),
             build_response(
                 [{'id': '3', 'value': 'item3'},
-                 {'id': '4', 'value': 'item4'}, ],
-                 {'Next-Page': link}),
+                 {'id': '4', 'value': 'item4'}, ]
+            ),
             # Second one returns a list of items without a pagination token.
             build_response(
                 [{'id': '5', 'value': 'item5'},
@@ -855,22 +855,10 @@ class RecordTest(unittest.TestCase):
             ),
         ]
 
-        response = [
-            # First one returns a list of items with a pagination token.
-            build_response(
-                [{'id': '1', 'value': 'item1'},
-                 {'id': '2', 'value': 'item2'}, ],
-            )[0],
-            build_response(
-                [{'id': '3', 'value': 'item3'},
-                 {'id': '4', 'value': 'item4'}, ]
-            )[0],
-            # Second one returns a list of items without a pagination token.
-            build_response(
-                [{'id': '5', 'value': 'item5'},
-                 {'id': '6', 'value': 'item6'}, ],
-            )[0],
-        ]
+        self.session.request.side_effect = response
+
+        # Build repsonses for assertion without next page
+        response = [record[0] for record in response]
 
         for index, page_records in enumerate(self.client.get_paginated_records()):
             assert response[index] == page_records


### PR DESCRIPTION
Solves #175 

* [x]  Add tests.
* [x] Create ``client.get_paginated_records`` method.
* [x] Make tests run correctly on Travis-CI.
* [x]  Add a changelog entry.
* [x] Add _limit parameter.
* [x] Add if_none_match.