### PR TITLE
Allow additional query parameters in get_*() methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,10 @@ This document describes changes between each past release.
 10.2.0 (unreleased)
 ===================
 
-**New feature**
+**New features**
 
 - Created new method on client to get paginated records ``get_paginated_records``. (#175)
-
+- Allow additional querystring params in `get_*()` methods
 
 10.1.1 (2018-11-13)
 ===================

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -319,13 +319,13 @@ class Client(object):
         endpoint = self.get_endpoint('buckets')
         return self._paginated(endpoint, **kwargs)
 
-    def get_bucket(self, *, id=None):
+    def get_bucket(self, *, id=None, **kwargs):
         endpoint = self.get_endpoint('bucket', bucket=id)
 
         logger.info("Get bucket %r" % id or self._bucket_name)
 
         try:
-            resp, _ = self.session.request('get', endpoint)
+            resp, _ = self.session.request('get', endpoint, params=kwargs)
         except KintoException as e:
             error_resp_code = e.response.status_code
             if error_resp_code == 401:
@@ -588,7 +588,7 @@ class Client(object):
             if_match=if_match,
         )
 
-    def get_collection(self, *, id=None, bucket=None):
+    def get_collection(self, *, id=None, bucket=None, **kwargs):
         endpoint = self.get_endpoint('collection',
                                      bucket=bucket,
                                      collection=id)
@@ -597,7 +597,7 @@ class Client(object):
                     (id or self._collection_name, bucket or self._bucket_name))
 
         try:
-            resp, _ = self.session.request('get', endpoint)
+            resp, _ = self.session.request('get', endpoint, params=kwargs)
         except KintoException as e:
             error_resp_code = e.response.status_code
             if error_resp_code == 404:
@@ -678,7 +678,7 @@ class Client(object):
             yield from self._paginated_generator(next_page,
                                                  if_none_match=if_none_match)
 
-    def get_record(self, *, id, collection=None, bucket=None):
+    def get_record(self, *, id, collection=None, bucket=None, **kwargs):
         endpoint = self.get_endpoint('record', id=id,
                                      bucket=bucket,
                                      collection=collection)
@@ -687,7 +687,7 @@ class Client(object):
           "Get record with id %r from collection %r in bucket %r"
           % (id, collection or self._collection_name, bucket or self._bucket_name))
 
-        resp, _ = self.session.request('get', endpoint)
+        resp, _ = self.session.request('get', endpoint, params=kwargs)
         return resp
 
     def create_record(self, *, id=None, bucket=None, collection=None,

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -183,7 +183,7 @@ class ClientTest(unittest.TestCase):
         mock_response(self.session)
         client = Client(session=self.session)
         client.get_bucket()
-        self.session.request.assert_called_with('get', '/buckets/default')
+        self.session.request.assert_called_with('get', '/buckets/default', params={})
 
     def test_client_uses_passed_bucket_if_specified(self):
         client = Client(
@@ -330,12 +330,17 @@ class BucketTest(unittest.TestCase):
 
     def test_get_is_issued_on_retrieval(self):
         self.client.get_bucket(id='testbucket')
-        self.session.request.assert_called_with('get', '/buckets/testbucket')
+        self.session.request.assert_called_with('get', '/buckets/testbucket', params={})
 
     def test_bucket_names_are_slugified(self):
         self.client.get_bucket(id='my bucket')
         url = '/buckets/my-bucket'
-        self.session.request.assert_called_with('get', url)
+        self.session.request.assert_called_with('get', url, params={})
+
+    def test_get_bucket_supports_queryparams(self):
+        self.client.get_bucket(id='bid', _expected="123")
+        url = '/buckets/bid'
+        self.session.request.assert_called_with('get', url, params={"_expected": "123"})
 
     def test_permissions_are_retrieved(self):
         mock_response(self.session, permissions={'read': ['phrawzty', ]})
@@ -487,7 +492,12 @@ class CollectionTest(unittest.TestCase):
     def test_collection_names_are_slugified(self):
         self.client.get_collection(id='my collection')
         url = '/buckets/mybucket/collections/my-collection'
-        self.session.request.assert_called_with('get', url)
+        self.session.request.assert_called_with('get', url, params={})
+
+    def test_get_collection_supports_queryparams(self):
+        self.client.get_collection(id='cid', _expected="123")
+        url = '/buckets/mybucket/collections/cid'
+        self.session.request.assert_called_with('get', url, params={"_expected": "123"})
 
     def test_collection_creation_issues_an_http_put(self):
         self.client.create_collection(id='mycollection',
@@ -767,7 +777,12 @@ class RecordTest(unittest.TestCase):
 
         self.assertEqual(record['data'], {'foo': 'bar'})
         url = '/buckets/mybucket/collections/mycollection/records/1234'
-        self.session.request.assert_called_with('get', url)
+        self.session.request.assert_called_with('get', url, params={})
+
+    def test_get_record_supports_queryparams(self):
+        self.client.get_record(id='1234', _expected="123")
+        url = '/buckets/mybucket/collections/mycollection/records/1234'
+        self.session.request.assert_called_with('get', url, params={"_expected": "123"})
 
     def test_collection_can_retrieve_all_records(self):
         mock_response(self.session, data=[{'id': 'foo'}, {'id': 'bar'}])


### PR DESCRIPTION
Will allow cache busting parameters when fetching collection metadata :)