### PR TITLE
Add access token support in client constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,10 @@ This document describes changes between each past release.
 10.3.0 (unreleased)
 ===================
 
-- Nothing changed yet.
+**New features**
+
+- Add support for OAuth access tokens (OpenID) via the ``access_token`` parameter in
+  client constructor
 
 
 10.2.0 (2018-12-17)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,7 @@ This document describes changes between each past release.
 
 **New features**
 
-- Add support for OAuth access tokens (OpenID) via the ``access_token`` parameter in
-  client constructor
+- Add support for OAuth access tokens (OpenID) with the ``BearerTokenAuth()`` helper. See README. (#197)
 
 
 10.2.0 (2018-12-17)

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,14 @@ Using a Bearer access token to authenticate (OpenID)
 
 .. code-block:: python
 
-    client = Client(bucket="main", collection="tippytop", access_token="XYPJTNsFKV2")
+    import kinto_http
+
+    client = kinto_http.Client(auth=kinto_http.BearerTokenAuth("XYPJTNsFKV2"))
+
+
+The authorization header is prefixed with ``Bearer`` by default. If the ``header_type``
+is `customized on the server <https://kinto.readthedocs.io/en/stable/configuration/settings.html#openid-connect>`_,
+the client must specify the expected type: ``kinto_http.BearerTokenAuth("XYPJTNsFKV2" type="Bearer+OIDC")``
 
 
 Using FxA from a script with the email/password

--- a/README.rst
+++ b/README.rst
@@ -90,23 +90,12 @@ some key arguments.
     client2 = client.clone(collection="orders")
 
 
-Using a Bearer token to authenticate
-------------------------------------
+Using a Bearer access token to authenticate (OpenID)
+----------------------------------------------------
 
 .. code-block:: python
 
-    import requests
-
-    class BearerTokenAuth(requests.auth.AuthBase):
-        def __init__(self, token):
-            self.token = token
-
-        def __call__(self, r):
-            r.headers['Authorization'] = 'Bearer ' + self.token
-            return r
-
-    auth = BearerTokenAuth("a67fjnewgre5")
-    client = Client(bucket="main", collection="tippytop", auth=auth)
+    client = Client(bucket="main", collection="tippytop", access_token="XYPJTNsFKV2")
 
 
 Using FxA from a script with the email/password

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -14,7 +14,7 @@ from kinto_http.patch_type import PatchType, BasicPatch
 
 logger = logging.getLogger('kinto_http')
 
-__all__ = ('Endpoints', 'Session', 'Client', 'create_session',
+__all__ = ('BearerTokenAuth', 'Endpoints', 'Session', 'Client', 'create_session',
            'BucketNotFound', 'CollectionNotFound', 'KintoException', 'KintoBatchException')
 
 
@@ -61,23 +61,21 @@ class Endpoints(object):
 
 
 class BearerTokenAuth(requests.auth.AuthBase):
-    def __init__(self, token):
+    def __init__(self, token, type=None):
         self.token = token
+        self.type = type or "Bearer"
 
     def __call__(self, r):
-        r.headers["Authorization"] = "Bearer " + self.token
+        r.headers["Authorization"] = "{} {}".format(self.type, self.token)
         return r
 
 
 class Client(object):
 
-    def __init__(self, *, server_url=None, session=None, access_token=None, auth=None,
+    def __init__(self, *, server_url=None, session=None, auth=None,
                  bucket="default", collection=None, retry=0, retry_after=None,
                  ignore_batch_4xx=False):
         self.endpoints = Endpoints()
-
-        if access_token is not None:
-            auth = BearerTokenAuth(access_token)
 
         session_kwargs = dict(server_url=server_url,
                               auth=auth,

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from kinto_http import (KintoException, KintoBatchException, BucketNotFound,
-                        Client, DO_NOT_OVERWRITE)
+                        BearerTokenAuth, Client, DO_NOT_OVERWRITE)
 from kinto_http.session import create_session
 from kinto_http.patch_type import MergePatch, JSONPatch
 
@@ -24,10 +24,10 @@ class ClientTest(unittest.TestCase):
         r = mock.MagicMock()
         r.headers = {}
 
-        client = Client(access_token="abc")
+        client = Client(auth=BearerTokenAuth("abc", type="Bearer+OIDC"))
         client.session.auth(r)
 
-        assert r.headers["Authorization"] == "Bearer abc"
+        assert r.headers["Authorization"] == "Bearer+OIDC abc"
 
     def test_context_manager_works_as_expected(self):
         settings = {"batch_max_requests": 25}

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -20,6 +20,15 @@ class ClientTest(unittest.TestCase):
         self.client.server_info()
         self.session.request.assert_called_with('get', '/')
 
+    def test_auth_from_access_token(self):
+        r = mock.MagicMock()
+        r.headers = {}
+
+        client = Client(access_token="abc")
+        client.session.auth(r)
+
+        assert r.headers["Authorization"] == "Bearer abc"
+
     def test_context_manager_works_as_expected(self):
         settings = {"batch_max_requests": 25}
         self.session.request.side_effect = [({"settings": settings}, []),


### PR DESCRIPTION
I'm not sure about the form it should take, but I'd like to avoid repeating this code in our kinto scripts...

I was also thinking of something like this:
```py
if auth and isinstance(auth, str):
    auth = tuple(auth.split(":", 1)) if ":" in auth else BearerTokenAuth(auth)
```
but seems less explicit..