### PR TITLE
Allow to specify timeout in client constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This document describes changes between each past release.
 10.6.0 (unreleased)
 ===================
 
-- Nothing changed yet.
+**New features**
+
+- Specify requests timeout in client constructor
 
 
 10.5.0 (2019-09-10)

--- a/README.rst
+++ b/README.rst
@@ -263,6 +263,30 @@ Failing operations will raise a ``KintoException``, which has ``request`` and ``
             print("Not allowed!")
 
 
+Requests Timeout
+----------------
+
+A ``timeout`` value in seconds can be specified in the client constructor:
+
+.. code-block:: python
+
+    client = KintoClient(server_url="...", timeout=5)
+
+To distinguish the connect from the read timeout, use a tuple:
+
+.. code-block:: python
+
+    client = KintoClient(server_url="...", timeout=(3.05, 27))
+
+For an infinit timeout, use ``None``:
+
+.. code-block:: python
+
+    client = KintoClient(server_url="...", timeout=None)
+
+See the `timeout documentation <https://2.python-requests.org//en/master/user/advanced/#timeouts>`_ of the underlying ``requests`` library.
+
+
 Retry on error
 --------------
 

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -92,12 +92,14 @@ class Client(object):
         collection=None,
         retry=0,
         retry_after=None,
+        timeout=None,
         ignore_batch_4xx=False
     ):
         self.endpoints = Endpoints()
 
         session_kwargs = dict(
-            server_url=server_url, auth=auth, session=session, retry=retry, retry_after=retry_after
+            server_url=server_url, auth=auth, session=session, retry=retry, retry_after=retry_after,
+            timeout=timeout,
         )
         self.session = create_session(**session_kwargs)
         self._bucket_name = bucket

--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -98,7 +98,8 @@ class Client(object):
         self.endpoints = Endpoints()
 
         session_kwargs = dict(
-            server_url=server_url, auth=auth, session=session, retry=retry, retry_after=retry_after,
+            server_url=server_url, auth=auth, session=session,
+            retry=retry, retry_after=retry_after,
             timeout=timeout,
         )
         self.session = create_session(**session_kwargs)

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -19,9 +19,6 @@ USER_AGENT = "kinto_http/{} requests/{} python/{}".format(
 )
 
 
-unset = object()
-
-
 def create_session(server_url=None, auth=None, session=None, **kwargs):
     """Returns a session from the passed arguments.
 
@@ -52,7 +49,7 @@ class Session(object):
     """Handles all the interactions with the network.
     """
 
-    def __init__(self, server_url, auth=None, timeout=unset, retry=0, retry_after=None):
+    def __init__(self, server_url, auth=None, timeout=False, retry=0, retry_after=None):
         self.backoff = None
         self.server_url = server_url
         self.auth = auth
@@ -72,7 +69,7 @@ class Session(object):
         else:
             actual_url = endpoint
 
-        if self.timeout != unset:
+        if not isinstance(self.timeout, bool):
             kwargs.setdefault("timeout", self.timeout)
 
         if self.auth is not None:

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -19,6 +19,9 @@ USER_AGENT = "kinto_http/{} requests/{} python/{}".format(
 )
 
 
+unset = object()
+
+
 def create_session(server_url=None, auth=None, session=None, **kwargs):
     """Returns a session from the passed arguments.
 
@@ -49,12 +52,13 @@ class Session(object):
     """Handles all the interactions with the network.
     """
 
-    def __init__(self, server_url, auth=None, retry=0, retry_after=None):
+    def __init__(self, server_url, auth=None, timeout=unset, retry=0, retry_after=None):
         self.backoff = None
         self.server_url = server_url
         self.auth = auth
         self.nb_retry = retry
         self.retry_after = retry_after
+        self.timeout = timeout
 
     def request(self, method, endpoint, data=None, permissions=None, payload=None, **kwargs):
         current_time = time.time()
@@ -67,6 +71,9 @@ class Session(object):
             actual_url = utils.urljoin(self.server_url, endpoint)
         else:
             actual_url = endpoint
+
+        if self.timeout != unset:
+            kwargs.setdefault("timeout", self.timeout)
 
         if self.auth is not None:
             kwargs.setdefault("auth", self.auth)

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -69,7 +69,7 @@ class Session(object):
         else:
             actual_url = endpoint
 
-        if not isinstance(self.timeout, bool):
+        if self.timeout is not False:
             kwargs.setdefault("timeout", self.timeout)
 
         if self.auth is not None:

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -33,6 +33,28 @@ class SessionTest(unittest.TestCase):
         session = Session(mock.sentinel.server_url)
         self.assertEqual(session.server_url, mock.sentinel.server_url)
 
+    def test_timeout_can_be_set_to_none(self):
+        response = fake_response(200)
+        self.requests_mock.request.return_value = response
+        session = Session("https://example.org", timeout=None)
+        self.assertEqual(session.auth, None)
+        session.request("get", "/test")
+        self.requests_mock.request.assert_called_with(
+            "get", "https://example.org/test", timeout=None,
+            headers=self.requests_mock.request.headers
+        )
+
+    def test_timeout_can_be_set_to_value(self):
+        response = fake_response(200)
+        self.requests_mock.request.return_value = response
+        session = Session("https://example.org", timeout=4)
+        self.assertEqual(session.auth, None)
+        session.request("get", "/test")
+        self.requests_mock.request.assert_called_with(
+            "get", "https://example.org/test", timeout=4,
+            headers=self.requests_mock.request.headers
+        )
+
     def test_no_auth_is_used_by_default(self):
         response = fake_response(200)
         self.requests_mock.request.return_value = response


### PR DESCRIPTION
Since requests 2.4, we can specify a `timeout` param to requests