### PR TITLE
Fix linting errors

### DIFF
--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -46,8 +46,7 @@ def create_session(server_url=None, auth=None, session=None, **kwargs):
 
 
 class Session(object):
-    """Handles all the interactions with the network.
-    """
+    """Handles all the interactions with the network."""
 
     def __init__(
         self, server_url, auth=None, timeout=False, headers=None, retry=0, retry_after=None

--- a/kinto_http/utils.py
+++ b/kinto_http/utils.py
@@ -38,15 +38,15 @@ def quote(text):
     return '"{0}"'.format(text)
 
 
-def chunks(l, n):
-    """Yield successive n-sized chunks from l.
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst.
     Source: http://stackoverflow.com/a/312464
     """
     if n > 0:
-        for i in range(0, len(l), n):
-            yield l[i : i + n]
+        for i in range(0, len(lst), n):
+            yield lst[i : i + n]
     else:
-        yield l
+        yield lst
 
 
 def json_iso_datetime(obj):


### PR DESCRIPTION
This PR renames the ambigious variable `l` to `lst` to prevent confusion (and to make flake8 happy), and ensures that all files are black formatted.