### PR TITLE
#174 custom user-agent for Client() and client.update_record()

### DIFF
--- a/kinto_http/__init__.py
+++ b/kinto_http/__init__.py
@@ -97,7 +97,6 @@ class Client(object):
         headers=None,
     ):
         self.endpoints = Endpoints()
-
         session_kwargs = dict(
             server_url=server_url,
             auth=auth,
@@ -780,6 +779,7 @@ class Client(object):
         permissions=None,
         safe=True,
         if_match=None,
+        user_agent=None,
     ):
         id = id or data.get("id")
         if id is None:
@@ -792,6 +792,8 @@ class Client(object):
             % (id, collection or self._collection_name, bucket or self._bucket_name)
         )
 
+        if user_agent:
+           self.session.headers['User-Agent'] = user_agent
         resp, _ = self.session.request(
             "put", endpoint, data=data, headers=headers, permissions=permissions
         )

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -60,8 +60,7 @@ class Session(object):
         self.headers = headers or {}
 
         # Set the default User-Agent if not already defined in the headers.
-        if "User-Agent" not in self.headers:
-           self.headers["User-Agent"] = USER_AGENT
+        self.headers.setdefault("User-Agent", USER_AGENT)
 
     def request(self, method, endpoint, data=None, permissions=None, payload=None, **kwargs):
         current_time = time.time()
@@ -82,7 +81,7 @@ class Session(object):
             kwargs.setdefault("auth", self.auth)
 
         if kwargs.get("params") is not None:
-            params = dict()  
+            params = dict()
             for key, value in kwargs["params"].items():
                 if key.startswith("in_") or key.startswith("exclude_"):
                     params[key] = ",".join(value)

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -59,6 +59,10 @@ class Session(object):
         self.timeout = timeout
         self.headers = headers or {}
 
+        # Set the default User-Agent if not already defined in the headers.
+        if "User-Agent" not in self.headers:
+           self.headers["User-Agent"] = USER_AGENT
+
     def request(self, method, endpoint, data=None, permissions=None, payload=None, **kwargs):
         current_time = time.time()
         if self.backoff and self.backoff > current_time:
@@ -78,7 +82,7 @@ class Session(object):
             kwargs.setdefault("auth", self.auth)
 
         if kwargs.get("params") is not None:
-            params = dict()
+  
             for key, value in kwargs["params"].items():
                 if key.startswith("in_") or key.startswith("exclude_"):
                     params[key] = ",".join(value)
@@ -89,9 +93,7 @@ class Session(object):
             kwargs["params"] = params
 
         overridden_headers = kwargs.get("headers") or {}
-
-        # Set the default User-Agent if not already defined.
-        kwargs["headers"] = {"User-Agent": USER_AGENT, **self.headers, **overridden_headers}
+        kwargs["headers"] = {**self.headers, **overridden_headers}
 
         payload = payload or {}
         if data is not None:

--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -82,7 +82,7 @@ class Session(object):
             kwargs.setdefault("auth", self.auth)
 
         if kwargs.get("params") is not None:
-  
+            params = dict()  
             for key, value in kwargs["params"].items():
                 if key.startswith("in_") or key.startswith("exclude_"):
                     params[key] = ",".join(value)

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 import pytest
 import time
+from kinto_http.tests.functional import SERVER_URL
 
 from kinto_http import (
     KintoException,
@@ -35,7 +36,7 @@ class ClientTest(unittest.TestCase):
 
     def test_create_client_with_default_user_agent(self):
         self.client = Client(server_url="https://kinto.notmyidea.org/v1")
-        assert self.client.headers["User-Agent"] == USER_AGENT
+        assert self.client.session.headers["User-Agent"] == USER_AGENT
         
     def test_auth_from_access_token(self):
         r = mock.MagicMock()
@@ -1206,18 +1207,13 @@ class RecordTest(unittest.TestCase):
 
     def test_update_record_can_update_user_agent(self):
         new_agent_name = "new_agent" + str(time.time())
-        assert self.client.session.user_agent != new_agent_name
-        self.client.update_record(data={"id": "record"}, collection="coll", user_agent=new_agent_name)
-        assert self.client.session.headers["User-Agent"] == new_agent_name
-        self.session.request.assert_called_with(
-            "put",
-            "/buckets/buck/collections/coll/records/record",
-            data={"id": "record"},
-            permissions=None,
-            headers=None,
-        )
-
-
+        self.client = Client(server_url=SERVER_URL)
+        assert self.client.session.headers["User-Agent"] != new_agent_name
+        try:
+            self.client.update_record(data={"id": "record"}, bucket="buck",\
+                collection="coll", user_agent=new_agent_name)
+        except:
+            assert self.client.session.headers["User-Agent"] == new_agent_name
 
 class HistoryTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
https://github.com/Kinto/kinto-http.py/issues/174
Adding capability for the user to specify customer user-agent through Client(headers={"User-Agent": "<Custom value>"}) constructor and update the user-agent through client.update_record(user_agent="<Custom value>")