### PR TITLE
Fix#54 Throw warnings.warn(response.headers['Alert'], DeprecationWarning)

### DIFF
--- a/kinto_http/session.py
+++ b/kinto_http/session.py
@@ -2,13 +2,13 @@ import json
 import pkg_resources
 import sys
 import time
+import warnings
 from urllib.parse import urlparse
 
 import requests
 
 from kinto_http import utils
 from kinto_http.exceptions import KintoException, BackoffException
-
 
 kinto_http_version = pkg_resources.get_distribution("kinto_http").version
 requests_version = pkg_resources.get_distribution("requests").version
@@ -110,6 +110,8 @@ class Session(object):
         retry = self.nb_retry
         while retry >= 0:
             resp = requests.request(method, actual_url, **kwargs)
+            if "Alert" in resp.headers:
+                warnings.warn(resp.headers["Alert"], DeprecationWarning)
             backoff_seconds = resp.headers.get("Backoff")
             if backoff_seconds:
                 self.backoff = time.time() + int(backoff_seconds)

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -10,7 +10,6 @@ from datetime import date, datetime
 from kinto_http.session import Session, create_session
 from kinto_http.exceptions import KintoException, BackoffException
 from kinto_http.session import USER_AGENT
-from kinto_http.tests.functional import SERVER_URL, DEFAULT_AUTH
 from .support import get_200, get_503, get_403, get_http_response
 
 def fake_response(status_code):

--- a/kinto_http/tests/test_session.py
+++ b/kinto_http/tests/test_session.py
@@ -3,14 +3,15 @@ import pytest
 import sys
 import time
 import unittest
+import warnings
 from unittest import mock
 from datetime import date, datetime
 
 from kinto_http.session import Session, create_session
 from kinto_http.exceptions import KintoException, BackoffException
 from kinto_http.session import USER_AGENT
+from kinto_http.tests.functional import SERVER_URL, DEFAULT_AUTH
 from .support import get_200, get_503, get_403, get_http_response
-
 
 def fake_response(status_code):
     response = mock.MagicMock()
@@ -244,6 +245,18 @@ class SessionTest(unittest.TestCase):
         assert requests_info == "requests/{}".format(requests_version)
         assert python_info == "python/{}".format(python_version)
 
+    def test_deprecation_warning_on_deprecated_endpoint(self):
+        response = fake_response(200)
+        response.headers = {}
+        response.headers['Alert'] = str({'code':'testcode', 'message':'You are deprecated','url':'http://updateme.com'})
+        self.requests_mock.request.return_value = response
+        session = Session("http://localhost:8888/v1")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            session.request("GET", "buckets?_to=1")
+
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
 class SessionJSONTest(unittest.TestCase):
     def setUp(self):
@@ -430,3 +443,4 @@ class RetryRequestTest(unittest.TestCase):
         time.sleep(1)  # Spend the backoff
         session.request("get", "/test")  # The second call reset the backoff
         self.assertIsNone(session.backoff)
+


### PR DESCRIPTION
Throw warnings.warn(response.headers['Alert'], DeprecationWarning) when the request's response's header contains 'Alert' element. Also added new unit test. 334 passed in 51.18s

https://github.com/Kinto/kinto-http.py/issues/54