### PR TITLE
Fix `clone()` method with subclasses

### DIFF
--- a/kinto_http/client.py
+++ b/kinto_http/client.py
@@ -69,7 +69,7 @@ class Client(object):
         kwargs.setdefault("collection", self.collection_name)
         kwargs.setdefault("retry", self.session.nb_retry)
         kwargs.setdefault("retry_after", self.session.retry_after)
-        return Client(**kwargs)
+        return self.__class__(**kwargs)
 
     @retry_timeout
     @contextmanager
@@ -932,7 +932,7 @@ class AsyncClient(object):
         kwargs.setdefault("collection", self.collection_name)
         kwargs.setdefault("retry", self.session.nb_retry)
         kwargs.setdefault("retry_after", self.session.retry_after)
-        return AsyncClient(**kwargs)
+        return self.__class__(**kwargs)
 
     async def server_info(self) -> Dict:
         loop = asyncio.get_event_loop()

--- a/kinto_http/tests/test_client.py
+++ b/kinto_http/tests/test_client.py
@@ -246,6 +246,17 @@ def test_client_can_receive_default_headers(mocker: MockerFixture):
     assert "Allow-Access" in mocked.request.call_args_list[0][1]["headers"]
 
 
+def test_client_clone_from_subclass():
+    class SubClient(Client):
+        def qwack(self):
+            return True
+
+    client = SubClient(server_url="https://duck.com", bucket="bar")
+    client2 = client.clone(bucket="foo")
+    assert client2.qwack()
+    assert client2.bucket_name == "foo"
+
+
 def test_client_clone_with_auth(client_setup: Client):
     client = client_setup
     client_clone = client.clone(auth=("reviewer", ""))


### PR DESCRIPTION
Without this fix, the `.clone()` method does not return instances of subclasses