### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/src/kinto_http/constants.py
+++ b/src/kinto_http/constants.py
@@ -1,6 +1,6 @@
+import importlib.metadata
 import re
 import sys
-import importlib.metadata
 
 
 kinto_http_version = importlib.metadata.version("kinto_http")

--- a/src/kinto_http/constants.py
+++ b/src/kinto_http/constants.py
@@ -1,11 +1,10 @@
 import re
 import sys
+import importlib.metadata
 
-import pkg_resources
 
-
-kinto_http_version = pkg_resources.get_distribution("kinto_http").version
-requests_version = pkg_resources.get_distribution("requests").version
+kinto_http_version = importlib.metadata.version("kinto_http")
+requests_version = importlib.metadata.version("requests")
 python_version = ".".join(map(str, sys.version_info[:3]))
 
 USER_AGENT = "kinto_http/{} requests/{} python/{}".format(


### PR DESCRIPTION
* Replaces `pkg_resources` with standard `importlib` . `pkg_resources` is a part of `setuptools`, and https://github.com/python/cpython/issues/95299 removes setuptools from Python environments. It would need to be manually added to the requirements 👎 

Required for https://github.com/mozilla-services/remote-settings-lambdas/pull/1474