### PR TITLE
Add methods related to Remote Settings plugin

### DIFF
--- a/src/kinto_http/client.py
+++ b/src/kinto_http/client.py
@@ -5,6 +5,7 @@ import json
 import logging
 import mimetypes
 import os
+import random
 import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -912,6 +913,61 @@ class Client(object):
         endpoint = self._get_endpoint("attachment", id=id, bucket=bucket, collection=collection)
         resp, _ = self.session.request("delete", endpoint)
         return resp
+
+    def get_changeset(self, bucket=None, collection=None, bust_cache=False, **kwargs):
+        kwargs.setdefault(
+            "_expected", random.randint(999999000000, 999999999999) if bust_cache else 0
+        )
+        endpoint = self._get_endpoint("changeset", bucket=bucket, collection=collection)
+        resp, _ = self.session.request("get", endpoint, params=kwargs)
+        return resp
+
+    def request_review(self, message, id=None, bucket=None, **kwargs):
+        return self.patch_collection(
+            id=id,
+            bucket=bucket,
+            data={
+                **kwargs.pop("data", {}),
+                "status": "to-review",
+                "last_editor_comment": message,
+            },
+            **kwargs,
+        )
+
+    def decline_changes(self, message, id=None, bucket=None, **kwargs):
+        return self.patch_collection(
+            id=id,
+            bucket=bucket,
+            data={
+                **kwargs.pop("data", {}),
+                "status": "work-in-progress",
+                "last_reviewer_comment": message,
+            },
+            **kwargs,
+        )
+
+    def approve_changes(self, id=None, bucket=None, **kwargs):
+        return self.patch_collection(
+            id=id,
+            bucket=bucket,
+            data={
+                **kwargs.pop("data", {}),
+                "status": "to-sign",
+            },
+            **kwargs,
+        )
+
+    def rollback_changes(self, message, id=None, bucket=None, **kwargs):
+        return self.patch_collection(
+            id=id,
+            bucket=bucket,
+            data={
+                **kwargs.pop("data", {}),
+                "status": "to-rollback",
+                "last_editor_comment": message,
+            },
+            **kwargs,
+        )
 
     def __repr__(self) -> str:
         if self.collection_name:

--- a/src/kinto_http/endpoints.py
+++ b/src/kinto_http/endpoints.py
@@ -22,6 +22,7 @@ class Endpoints(object):
         "records": "{root}/buckets/{bucket}/collections/{collection}/records",  # NOQA
         "record": "{root}/buckets/{bucket}/collections/{collection}/records/{id}",  # NOQA
         "attachment": "{root}/buckets/{bucket}/collections/{collection}/records/{id}/attachment",  # NOQA
+        "changeset": "{root}/buckets/{bucket}/collections/{collection}/changeset",  # NOQA
     }
 
     def __init__(self, root=""):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1433,3 +1433,105 @@ def test_get_permissions(client_setup: Client):
             "_sort": "id",
         },
     )
+
+
+def test_get_changeset_default(client_setup: Client):
+    client = client_setup
+    client.collection_name = "foo"
+    mock_response(client.session)
+
+    client.get_changeset()
+    client.session.request.assert_called_with(
+        "get", "/buckets/mybucket/collections/foo/changeset", params={"_expected": 0}
+    )
+
+
+def test_get_changeset_bust(client_setup: Client, mocker: MockerFixture):
+    client = client_setup
+    mock_response(client.session)
+    mocked_random = mocker.patch("kinto_http.client.random")
+    mocked_random.randint.return_value = 42
+
+    client.get_changeset(collection="bar", bust_cache=True)
+    client.session.request.assert_called_with(
+        "get", "/buckets/mybucket/collections/bar/changeset", params={"_expected": 42}
+    )
+
+
+def test_get_changeset_params(client_setup: Client, mocker: MockerFixture):
+    client = client_setup
+    mock_response(client.session)
+
+    client.get_changeset(bucket="foo", collection="bar", _since='"42"')
+    client.session.request.assert_called_with(
+        "get", "/buckets/foo/collections/bar/changeset", params={"_expected": 0, "_since": '"42"'}
+    )
+
+
+def test_request_review(client_setup: Client, mocker: MockerFixture):
+    client = client_setup.clone(collection="cid")
+    mock_response(client.session)
+
+    client.request_review("r?")
+    client.session.request.assert_called_with(
+        "patch",
+        "/buckets/mybucket/collections/cid",
+        headers={"Content-Type": "application/json"},
+        payload={"data": {"last_editor_comment": "r?", "status": "to-review"}},
+    )
+
+
+def test_request_review_advanced(client_setup: Client, mocker: MockerFixture):
+    client = client_setup
+    mock_response(client.session)
+
+    client.request_review("r?", id="cid", data={"field": "foo"}, if_match='"42"')
+    client.session.request.assert_called_with(
+        "patch",
+        "/buckets/mybucket/collections/cid",
+        headers={"Content-Type": "application/json", "If-Match": '"42"'},
+        payload={"data": {"field": "foo", "last_editor_comment": "r?", "status": "to-review"}},
+    )
+
+
+def test_approve_changes(client_setup: Client, mocker: MockerFixture):
+    client = client_setup
+    mock_response(client.session)
+
+    client.approve_changes(id="cid", data={"field": "foo"}, if_match='"42"')
+    client.session.request.assert_called_with(
+        "patch",
+        "/buckets/mybucket/collections/cid",
+        headers={"Content-Type": "application/json", "If-Match": '"42"'},
+        payload={"data": {"field": "foo", "status": "to-sign"}},
+    )
+
+
+def test_decline_changes(client_setup: Client, mocker: MockerFixture):
+    client = client_setup
+    mock_response(client.session)
+
+    client.decline_changes(message="r-", id="cid", data={"field": "foo"}, if_match='"42"')
+    client.session.request.assert_called_with(
+        "patch",
+        "/buckets/mybucket/collections/cid",
+        headers={"Content-Type": "application/json", "If-Match": '"42"'},
+        payload={
+            "data": {"field": "foo", "last_reviewer_comment": "r-", "status": "work-in-progress"}
+        },
+    )
+
+
+def test_rollback_changes(client_setup: Client, mocker: MockerFixture):
+    client = client_setup
+    mock_response(client.session)
+
+    client.rollback_changes(message="cancel", id="cid", data={"field": "foo"}, if_match='"42"')
+    client.session.request.assert_called_with(
+        "patch",
+        "/buckets/mybucket/collections/cid",
+        headers={"Content-Type": "application/json", "If-Match": '"42"'},
+        payload={
+            "data": {"field": "foo", "last_editor_comment": "cancel", "status": "to-rollback"}
+        },
+    )


### PR DESCRIPTION
Even though they are not related to kinto core, having these high level methods don't harm, and facilitate the interaction with Remote Settings

See https://github.com/mozilla-services/telescope/blob/8923af3c236c780e98d0c1a285770b0b11e7e6bb/checks/remotesettings/utils.py#L51-L68
