### PR TITLE
Change the attachment request to pass a file handle rather than reading in the bytes

### DIFF
--- a/src/kinto_http/client.py
+++ b/src/kinto_http/client.py
@@ -923,20 +923,20 @@ class Client(object):
         permissions=None,
         mimetype=None,
     ):
-        with open(filepath, "rb") as f:
-            filecontent = f.read()
         filename = os.path.basename(filepath)
         if mimetype is None:
             mimetype, _ = mimetypes.guess_type(filepath)
-        multipart = [("attachment", (filename, filecontent, mimetype))]
         endpoint = self._get_endpoint("attachment", id=id, bucket=bucket, collection=collection)
-        resp, _ = self.session.request(
-            "post",
-            endpoint,
-            data=json.dumps(data) if data is not None else None,
-            permissions=json.dumps(permissions) if permissions is not None else None,
-            files=multipart,
-        )
+
+        with open(filepath, "rb") as file:
+            resp, _ = self.session.request(
+                "post",
+                endpoint,
+                data=json.dumps(data) if data is not None else None,
+                permissions=json.dumps(permissions) if permissions is not None else None,
+                files=[("attachment", (filename, file, mimetype))],
+            )
+
         return resp
 
     @retry_timeout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1428,14 +1428,12 @@ def test_add_attachment_guesses_mimetype(record_setup: Client, tmp_path):
     client = record_setup
     mock_response(client.session)
 
-    p = tmp_path / "file.txt"
-    p.write_text("hello")
     with patch("builtins.open", mock_open(read_data="hello")) as mock_file:
         client.add_attachment(
             id="abc",
             bucket="a",
             collection="b",
-            filepath=p,
+            filepath="file.txt",
         )
 
         client.session.request.assert_called_with(


### PR DESCRIPTION
I was having some attachments get truncated when using this API, and tracked it down to the line where the file is being read into bytes. I'm not sure _why_ this is truncating the file, but the fix is to pass in a file handle instead to requests.