### PR TITLE
Consistency drive-by fixes in session code

### DIFF
--- a/src/kinto_http/session.py
+++ b/src/kinto_http/session.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import time
 import warnings
 from urllib.parse import urlencode, urlparse
@@ -103,7 +104,7 @@ class Session(object):
             params = dict()
             for key, value in kwargs["params"].items():
                 if key.startswith("in_") or key.startswith("exclude_"):
-                    params[key] = ",".join(value)
+                    params[key] = f"{value}," if isinstance(value, str) else ",".join(value)
                 elif isinstance(value, str):
                     params[key] = value
                 else:
@@ -117,7 +118,7 @@ class Session(object):
 
         payload = payload or {}
 
-        if method.lower() == "get" and (payload or data):
+        if method.lower() in ("get", "head") and (payload or data):
             raise KintoException("GET requests are not allowed to have a body!")
 
         if data is not None:
@@ -140,7 +141,9 @@ class Session(object):
         retry = self.nb_retry
         while retry >= 0:
             if self.dry_mode:
-                qs = ("?" + urlencode(kwargs["params"])) if "params" in kwargs else ""
+                qs = (
+                    ("?" + urlencode(kwargs["params"])) if kwargs.get("params") is not None else ""
+                )
                 logger.debug(f"(dry mode) {method} {actual_url}{qs}")
                 resp = HTTPResponse(
                     status=200, headers={"Content-Type": "application/json"}, body=b"{}"
@@ -152,7 +155,7 @@ class Session(object):
             if "Alert" in resp.headers:
                 warnings.warn(resp.headers["Alert"], DeprecationWarning)
             backoff_seconds = resp.headers.get("Backoff")
-            if backoff_seconds:
+            if backoff_seconds and re.match(r"^\d+$", backoff_seconds):
                 self.backoff = time.time() + int(backoff_seconds)
             else:
                 self.backoff = None
@@ -162,17 +165,20 @@ class Session(object):
                 # Success
                 break
             else:
-                if retry >= 0 and (resp.status_code >= 500 or resp.status_code == 409):
+                if retry >= 0 and (resp.status_code >= 500 or resp.status_code in (409, 429)):
                     # Wait and try again.
                     # If not forced, use retry-after header and wait.
                     if self.retry_after is None:
-                        retry_after = int(resp.headers.get("Retry-After", 0))
+                        server_retryafter = resp.headers.get("Retry-After", 0)
+                        retry_after = (
+                            int(server_retryafter) if re.match(r"^\d+$", server_retryafter) else 0
+                        )
                     else:
                         retry_after = self.retry_after
                     time.sleep(retry_after)
                     continue
 
-                # Retries exhausted, raise expection.
+                # Retries exhausted, raise exception.
                 try:
                     message = "{0} - {1}".format(resp.status_code, resp.json())
                 except ValueError:
@@ -182,7 +188,7 @@ class Session(object):
                 exception.request = resp.request
                 exception.response = resp
                 raise exception
-        if resp.status_code == 204 or resp.status_code == 304 or method == "head":
+        if resp.status_code == 204 or resp.status_code == 304 or method.lower() == "head":
             body = None
         else:
             body = resp.json()

--- a/src/kinto_http/session.py
+++ b/src/kinto_http/session.py
@@ -181,7 +181,7 @@ class Session(object):
                     # Wait and try again.
                     # If not forced, use retry-after header and wait.
                     if self.retry_after is None:
-                        server_retryafter = resp.headers.get("Retry-After", 0)
+                        server_retryafter = resp.headers.get("Retry-After", "0")
                         retry_after = (
                             int(server_retryafter) if re.match(r"^\d+$", server_retryafter) else 0
                         )

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -77,6 +77,7 @@ def test_client_uses_passed_bucket_if_specified():
 async def test_client_can_receive_default_headers(mocker: MockerFixture):
     r = mocker.MagicMock()
     r.status_code = 200
+    r.headers = {}
     # AsyncClient runs requests in an executor thread (differ in main than executor).
     # Patch the class so all threads get the same mock.
     mocked = mocker.patch("kinto_http.session.requests.Session").return_value

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -242,6 +242,7 @@ def test_client_uses_passed_bucket_if_specified():
 def test_client_can_receive_default_headers(mocker: MockerFixture):
     r = mocker.MagicMock()
     r.status_code = 200
+    r.headers = {}
     client = Client(server_url="https://kinto.io/v1", headers={"Allow-Access": "CDN"})
     mocked = mocker.patch.object(client.session._session, "request", return_value=r)
     client.server_info()


### PR DESCRIPTION
- do not join on `,` if single string value is passed in `_in` or `_exclude`
- raise if body is passed to HEAD (like GET)
- do not try to encode `params=None`
- do not parse backoff and retry-after if they are not integers
- do not only retry 409 but also 429
